### PR TITLE
Adds silent option to ignore cmake output

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Options:
                                                                        [boolean]
   --CD                   Custom argument passed to CMake in format:
                          -D<your-arg-here>                              [string]
+  --si, --silent         Prevents cMake to print to the stdio          [boolean]
 ```
 
 **Requirements:**

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Options:
                                                                        [boolean]
   --CD                   Custom argument passed to CMake in format:
                          -D<your-arg-here>                              [string]
-  --si, --silent         Prevents cMake to print to the stdio          [boolean]
+  --i, --silent          CMake.js to print to the stdio                [boolean]
 ```
 
 **Requirements:**

--- a/bin/cmake-js
+++ b/bin/cmake-js
@@ -112,6 +112,11 @@ var yargs = require("yargs")
             demand: false,
             describe: "Custom argument passed to CMake in format: -D<your-arg-here>",
             type: "string"
+        },
+        "si": {
+            alias: "silent",
+            describe: "Prevents cMake to print to the stdio",
+            type: "boolean"
         }
     });
 var argv = yargs.argv;
@@ -155,7 +160,8 @@ var options = {
     runtime: argv.r,
     runtimeVersion: argv.v,
     arch: argv.a,
-    cMakeOptions: customOptions
+    cMakeOptions: customOptions,
+    silent: argv.si
 };
 
 log.verbose("CON", "options:");

--- a/bin/cmake-js
+++ b/bin/cmake-js
@@ -113,9 +113,9 @@ var yargs = require("yargs")
             describe: "Custom argument passed to CMake in format: -D<your-arg-here>",
             type: "string"
         },
-        "si": {
+        "i": {
             alias: "silent",
-            describe: "Prevents cMake to print to the stdio",
+            describe: "Prevents CMake.js to print to the stdio",
             type: "boolean"
         }
     });
@@ -161,7 +161,7 @@ var options = {
     runtimeVersion: argv.v,
     arch: argv.a,
     cMakeOptions: customOptions,
-    silent: argv.si
+    silent: argv.i
 };
 
 log.verbose("CON", "options:");

--- a/lib/es6/cMake.js
+++ b/lib/es6/cMake.js
@@ -28,6 +28,7 @@ function CMake(options) {
     this.targetOptions = new TargetOptions(this.options);
     this.toolset = new Toolset(this.options);
     this.cMakeOptions = this.options.cMakeOptions || {};
+    this.silent = !!options.silent;
 }
 
 Object.defineProperties(CMake.prototype, {
@@ -108,14 +109,14 @@ CMake.prototype.getConfigureCommand = async(function* () {
     command += " \"" + this.projectRoot + "\" --no-warn-unused-cli";
 
     let D = [];
-    
+
     // CMake.js watermark
     D.push({"CMAKE_JS_VERSION": environment.moduleVersion});
 
     // Build configuration:
     D.push({"CMAKE_BUILD_TYPE": this.config});
     if (environment.isWin) {
-		D.push({"CMAKE_RUNTIME_OUTPUT_DIRECTORY": this.workDir});		
+		D.push({"CMAKE_RUNTIME_OUTPUT_DIRECTORY": this.workDir});
 	}
 	else {
 		D.push({"CMAKE_LIBRARY_OUTPUT_DIRECTORY": this.buildDir});
@@ -301,7 +302,7 @@ CMake.prototype.compile = async(function* () {
 
 CMake.prototype._run = function (command) {
     this.log.info("RUN", command);
-    return processHelpers.run(command);
+    return processHelpers.run(command, this.silent);
 };
 
 module.exports = CMake;

--- a/lib/es6/cMake.js
+++ b/lib/es6/cMake.js
@@ -302,7 +302,7 @@ CMake.prototype.compile = async(function* () {
 
 CMake.prototype._run = function (command) {
     this.log.info("RUN", command);
-    return processHelpers.run(command, this.silent);
+    return processHelpers.run(command, {silent: this.silent});
 };
 
 module.exports = CMake;

--- a/lib/es6/processHelpers.js
+++ b/lib/es6/processHelpers.js
@@ -1,16 +1,18 @@
 "use strict";
 let Bluebird = require("bluebird");
 let splitargs = require("splitargs");
+let _ = require("lodash");
 let spawn = require("child_process").spawn;
 let exec = require("child_process").exec;
 
 let processHelpers = {
-    run: function (command, silent) {
+    run: function (command, options) {
+        options = _.defaults({silent: false}, options);
         return new Bluebird(function (resolve, reject) {
             let args = splitargs(command);
             let name = args[0];
             args.splice(0, 1);
-            let child = spawn(name, args, {stdio: silent ? "ignore" : "inherit"});
+            let child = spawn(name, args, {stdio: options.silent ? "ignore" : "inherit"});
             let ended = false;
             child.on("error", function (e) {
                 if (!ended) {

--- a/lib/es6/processHelpers.js
+++ b/lib/es6/processHelpers.js
@@ -5,12 +5,12 @@ let spawn = require("child_process").spawn;
 let exec = require("child_process").exec;
 
 let processHelpers = {
-    run: function (command) {
+    run: function (command, silent) {
         return new Bluebird(function (resolve, reject) {
             let args = splitargs(command);
             let name = args[0];
             args.splice(0, 1);
-            let child = spawn(name, args, {stdio: "inherit"});
+            let child = spawn(name, args, {stdio: silent ? "ignore" : "inherit"});
             let ended = false;
             child.on("error", function (e) {
                 if (!ended) {


### PR DESCRIPTION
This PR adds a `silent` option to ignore the cMake's output on the stdio.