### PR TITLE
Add -G command line option to specify generator

### DIFF
--- a/bin/cmake-js
+++ b/bin/cmake-js
@@ -72,6 +72,12 @@ var yargs = require("yargs")
             describe: "use GNU compiler instead of default CMake compiler, if available (Posix)",
             type: "boolean"
         },
+        G: {
+            alias: "generator",
+            demand: false,
+            describe: "use specified generator",
+            type: "string"
+        },
         C: {
             alias: "prefer-clang",
             demand: false,
@@ -157,6 +163,7 @@ var options = {
     directory: argv.directory || null,
     debug: argv.debug,
     cmakePath: argv.c || null,
+    generator: argv.G,
     preferMake: argv.m,
     preferXcode: argv.x,
     preferGnu: argv.g,

--- a/lib/es5/toolset.js
+++ b/lib/es5/toolset.js
@@ -11,7 +11,7 @@ var CMLog = require("./cmLog");
 function Toolset(options) {
   this.options = options || {};
   this.targetOptions = new TargetOptions(this.options);
-  this.generator = null;
+  this.generator = options.generator;
   this.cCompilerPath = null;
   this.cppCompilerPath = null;
   this.compilerFlags = [];
@@ -141,6 +141,10 @@ Toolset.prototype._setupGNUStd = function(install) {
 };
 Toolset.prototype.initializeWin = async($traceurRuntime.initGeneratorFunction(function $__9(install) {
   var topVS;
+  if( this.options.generator ){
+    this.generator = this.options.generator;
+    return $ctx.end();
+  }
   return $traceurRuntime.createGeneratorInstance(function($ctx) {
     while (true)
       switch ($ctx.state) {

--- a/lib/es5/toolset.js
+++ b/lib/es5/toolset.js
@@ -71,7 +71,13 @@ Toolset.prototype.initializePosix = function(install) {
     this.cppCompilerPath = "g++";
     this.cCompilerPath = "gcc";
   }
-  if (environment.isOSX) {
+  if( this.options.generator ){
+    if (install) {
+      this.log.info("TOOL", ("Using " + this.options.generator + " generator, as specified on command line."));
+    }
+    this.generator = this.options.generator;
+  }
+  else if (environment.isOSX) {
     if (this.options.preferXcode) {
       if (install) {
         this.log.info("TOOL", "Using Xcode generator, because preferXcode option is set.");
@@ -142,6 +148,9 @@ Toolset.prototype._setupGNUStd = function(install) {
 Toolset.prototype.initializeWin = async($traceurRuntime.initGeneratorFunction(function $__9(install) {
   var topVS;
   if( this.options.generator ){
+    if (install) {
+      this.log.info("TOOL", ("Using " + this.options.generator + " generator, as specified on command line."));
+    }
     this.generator = this.options.generator;
     return $ctx.end();
   }

--- a/lib/es5/toolset.js
+++ b/lib/es5/toolset.js
@@ -71,7 +71,7 @@ Toolset.prototype.initializePosix = function(install) {
     this.cppCompilerPath = "g++";
     this.cCompilerPath = "gcc";
   }
-  if( this.options.generator ){
+  if (this.options.generator) {
     if (install) {
       this.log.info("TOOL", ("Using " + this.options.generator + " generator, as specified on command line."));
     }

--- a/lib/es6/toolset.js
+++ b/lib/es6/toolset.js
@@ -60,7 +60,7 @@ Toolset.prototype.initializePosix = function (install) {
         this.cCompilerPath = "gcc";
     }
     // if it's already set because of options...
-    if( this.generator ){ 
+    if (this.generator) { 
         if (install) {
             this.log.info("TOOL", "Using " + this.options.generator + " generator, as specified from commandline.");
         }

--- a/lib/es6/toolset.js
+++ b/lib/es6/toolset.js
@@ -150,7 +150,7 @@ Toolset.prototype._setupGNUStd = function (install) {
 Toolset.prototype.initializeWin = async(function*(install) {
     // Visual Studio:
     // if it's already set because of options...
-    if( this.generator ){
+    if (this.generator) {
         if (install) {
             this.log.info("TOOL", "Using " + this.options.generator + " generator, as specified from commandline.");
         }

--- a/lib/es6/toolset.js
+++ b/lib/es6/toolset.js
@@ -12,7 +12,7 @@ let CMLog = require("./cmLog");
 function Toolset(options) {
     this.options = options || {};
     this.targetOptions = new TargetOptions(this.options);
-    this.generator = null;
+    this.generator = options.generator;
     this.cCompilerPath = null;
     this.cppCompilerPath = null;
     this.compilerFlags = [];
@@ -60,8 +60,14 @@ Toolset.prototype.initializePosix = function (install) {
         this.cCompilerPath = "gcc";
     }
 
+    if( this.options.generator ){
+        if (install) {
+            this.log.info("TOOL", "Using " + this.options.generator + " generator, as specified from commandline.");
+        }
+        this.generator = this.options.generator;
+    }
     // 2: Generator
-    if (environment.isOSX) {
+    else if (environment.isOSX) {
         if (this.options.preferXcode) {
             if (install) {
                 this.log.info("TOOL", "Using Xcode generator, because preferXcode option is set.");
@@ -144,6 +150,13 @@ Toolset.prototype._setupGNUStd = function (install) {
 
 Toolset.prototype.initializeWin = async(function*(install) {
     // Visual Studio:
+    if( this.options.generator ){
+        if (install) {
+            this.log.info("TOOL", "Using " + this.options.generator + " generator, as specified from commandline.");
+        }
+        this.generator = this.options.generator;
+        return;
+    }
     let topVS = yield this._getTopSupportedVisualStudioGenerator();
     //if (!this.options.noMSVC) {
     if (topVS) {

--- a/lib/es6/toolset.js
+++ b/lib/es6/toolset.js
@@ -60,11 +60,10 @@ Toolset.prototype.initializePosix = function (install) {
         this.cCompilerPath = "gcc";
     }
 
-    if( this.options.generator ){
+    if( this.generator ){ // if it's already set because of options...
         if (install) {
             this.log.info("TOOL", "Using " + this.options.generator + " generator, as specified from commandline.");
         }
-        this.generator = this.options.generator;
     }
     // 2: Generator
     else if (environment.isOSX) {
@@ -150,11 +149,10 @@ Toolset.prototype._setupGNUStd = function (install) {
 
 Toolset.prototype.initializeWin = async(function*(install) {
     // Visual Studio:
-    if( this.options.generator ){
+    if( this.generator ){ // if it's already set because of options...
         if (install) {
             this.log.info("TOOL", "Using " + this.options.generator + " generator, as specified from commandline.");
         }
-        this.generator = this.options.generator;
         return;
     }
     let topVS = yield this._getTopSupportedVisualStudioGenerator();

--- a/lib/es6/toolset.js
+++ b/lib/es6/toolset.js
@@ -59,8 +59,8 @@ Toolset.prototype.initializePosix = function (install) {
         this.cppCompilerPath = "g++";
         this.cCompilerPath = "gcc";
     }
-
-    if( this.generator ){ // if it's already set because of options...
+    // if it's already set because of options...
+    if( this.generator ){ 
         if (install) {
             this.log.info("TOOL", "Using " + this.options.generator + " generator, as specified from commandline.");
         }
@@ -149,7 +149,8 @@ Toolset.prototype._setupGNUStd = function (install) {
 
 Toolset.prototype.initializeWin = async(function*(install) {
     // Visual Studio:
-    if( this.generator ){ // if it's already set because of options...
+    // if it's already set because of options...
+    if( this.generator ){
         if (install) {
             this.log.info("TOOL", "Using " + this.options.generator + " generator, as specified from commandline.");
         }


### PR DESCRIPTION
Allow specification of generator from command line.
(Allows use of MinGW-64 instead of visual studio for instance) 

MUST complete; if a step fails when using this...

(MinGW Makefiles) cmake script complains if 'sh.exe' is in the path.  Normally I can just run ```cmake .``` again and finish the process... but cmake-js continues to error.
Second, I ended up doing it in an environment that was missing gcc, but didn't have sh.exe; so it finished with failure to find compilers, and retriggering failed.... 

But; deleting the build, having no sh.exe, having gcc in my path correctly - am able to finish building with 
cmake-js build -G "MinGW Makefiles" 


Error: could not find CMAKE_PROJECT_NAME in Cache
I guess; if it fails too soon that's the state.