### PR TITLE
Fixing missing SAFESEH option if generator used from option

### DIFF
--- a/lib/es6/toolset.js
+++ b/lib/es6/toolset.js
@@ -154,6 +154,12 @@ Toolset.prototype.initializeWin = async(function*(install) {
         if (install) {
             this.log.info("TOOL", "Using " + this.options.generator + " generator, as specified from commandline.");
         }
+        if (this.targetOptions.isX86) {
+            if (install) {
+                this.log.verbose("TOOL", "Setting SAFESEH:NO linker flag.");
+            }
+            this.linkerFlags.push("/SAFESEH:NO");
+        }
         return;
     }
     let topVS = yield this._getTopSupportedVisualStudioGenerator();


### PR DESCRIPTION
Using generator from new option leads to issue if SAFESEH needs to be set to NO.