### PR TITLE
Test output instead of guessing by platform

### DIFF
--- a/lib/es6/cMake.js
+++ b/lib/es6/cMake.js
@@ -71,7 +71,8 @@ CMake.getGenerators = async(function* (options) {
     let gens = [];
     if (CMake.isAvailable(options)) {
         let stdout = yield processHelpers.exec((options.cmakePath || "cmake") + " --help");
-        let output = environment.isWin ? stdout.split("\r\n") : stdout.split("\n");
+        let hasCr = stdout.includes("\r\n");
+        let output = hasCr ? stdout.split("\r\n") : stdout.split("\n");
         let on = false;
         output.forEach(function (line, i) {
             if (on) {


### PR DESCRIPTION
I have Windows Server 2012 
node v7.5.0  (x64)
cmake 3.8.0-rc1  (x64)

build tools installed with 'npm install -g windows-build-tools'

The output received at line 73 in this windows platform has only \n in the buffer.
If you test for 'if stdout.includes('\r\n')' then you can handle it based on what was given, instead of assuming a platform is going to be a certain way.

This was causing 
ERR! OMG There is no Visual C++ compiler installed. Install Visual C++ Build Toolset or Visual Studio.
ERR! OMG There is no Visual C++ compiler installed. Install Visual C++ Build Toolset or Visual Studio.

I tracked it back to _getTopSupportedVisualStudioGenerator had a list that was empty ... [] ... 
and that's because of the parsing error.