### PR TITLE
Update `tar` package

### DIFF
--- a/lib/es6/dist.js
+++ b/lib/es6/dist.js
@@ -147,13 +147,13 @@ Dist.prototype._downloadTar = async(function* (sums) {
 
     let sum = yield this.downloader.downloadTgz(tarUrl, {
         hash: sums ? "sha256" : null,
-        path: self.internalPath,
+        cwd: self.internalPath,
         strip: 1,
-        filter: function () {
-            if (this.path === self.internalPath) {
+        filter: function (entryPath) {
+            if (entryPath === self.internalPath) {
                 return true;
             }
-            let ext = path.extname(this.path);
+            let ext = path.extname(entryPath);
             return ext && ext.toLowerCase() === ".h";
         }
     });

--- a/lib/es6/downloader.js
+++ b/lib/es6/downloader.js
@@ -78,10 +78,10 @@ Downloader.prototype.downloadFile = async(function* (url, options) {
 
 Downloader.prototype.downloadTgz = async(function*(url, options) {
     if (_.isString(options)) {
-        options.path = options;
+        options.cwd = options;
     }
     let gunzip = zlib.createGunzip();
-    let extractor = new tar.Extract(options);
+    let extractor = tar.extract(options);
     gunzip.pipe(extractor);
     let sum =  yield this.downloadToStream(url, gunzip, options.hash);
     this.testSum(url, sum, options);

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "request": "^2.54.0",
     "semver": "^5.0.3",
     "splitargs": "0",
-    "tar": "^1.0.3",
+    "tar": "^3.1.5",
     "traceur": "0.0.x",
     "unzip": "^0.1.11",
     "url-join": "0",


### PR DESCRIPTION
`tar` v1.x has a known vulnerability which was fixed in v2.

This fixes issue #68 

For testing, I've built my Electron app on Mac and Windows. I've also used the `npm test` suite. Building the prototype for `nw` actually failed for me, on both platforms. However it also failed on `master` with the same error, so probably not related to the `tar` changes?
The error had to do with the `v8::JSON::Parse` signature being incorrect, the files were still successfully extracted to `~/.cmake-js`.