### PR TITLE
Add -T option to specify target to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ Options:
   -x, --prefer-xcode     use Xcode instead of Unix Makefiles           [boolean]
   -g, --prefer-gnu       use GNU compiler instead of default CMake compiler, if
                          available (Posix)                             [boolean]
+  -G, --generator        use specified generator                        [string]
+  -T, --target           only build the specified target                [string]
   -C, --prefer-clang     use Clang compiler instead of default CMake compiler,
                          if available (Posix)                          [boolean]
   -s, --std              C++ standard, eg.: c++98, c++11, c++14, etc., default
@@ -137,8 +139,9 @@ Options:
                                                                        [boolean]
   --CD                   Custom argument passed to CMake in format:
                          -D<your-arg-here>                              [string]
-  -i, --silent           Prevents CMake.js to print to the stdio        [boolean]
+  -i, --silent           Prevents CMake.js to print to the stdio       [boolean]
   -O, --out              Specify the output directory to compile to, default is
+                         projectRoot/build                              [string]
                          projectRoot/build                              [string]
 ```
 

--- a/bin/cmake-js
+++ b/bin/cmake-js
@@ -78,6 +78,12 @@ var yargs = require("yargs")
             describe: "use specified generator",
             type: "string"
         },
+        T: {
+            alias: "target",
+            demand: false,
+            describe: "only build the specified target",
+            type: "string"
+        },
         C: {
             alias: "prefer-clang",
             demand: false,
@@ -164,6 +170,7 @@ var options = {
     debug: argv.debug,
     cmakePath: argv.c || null,
     generator: argv.G,
+    target: argv.T,
     preferMake: argv.m,
     preferXcode: argv.x,
     preferGnu: argv.g,

--- a/lib/es5/cMake.js
+++ b/lib/es5/cMake.js
@@ -460,7 +460,11 @@ CMake.prototype.ensureConfigured = async($traceurRuntime.initGeneratorFunction(f
   }, $__19, this);
 }));
 CMake.prototype.getBuildCommand = function() {
-  return Bluebird.resolve(this.path + " --build \"" + this.workDir + "\" --config " + this.config);
+  var command = this.path + " --build \"" + this.workDir + "\" --config " + this.config;
+  if (this.options.target) {
+    command += " --target " + this.options.target;
+  }
+  return Bluebird.resolve(command);
 };
 CMake.prototype.build = async($traceurRuntime.initGeneratorFunction(function $__20() {
   var buildCommand;

--- a/lib/es5/toolset.js
+++ b/lib/es5/toolset.js
@@ -12,6 +12,7 @@ function Toolset(options) {
   this.options = options || {};
   this.targetOptions = new TargetOptions(this.options);
   this.generator = options.generator;
+  this.target = options.target;
   this.cCompilerPath = null;
   this.cppCompilerPath = null;
   this.compilerFlags = [];
@@ -114,6 +115,9 @@ Toolset.prototype.initializePosix = function(install) {
       }
       this.generator = "Unix Makefiles";
     }
+  }
+  if (this.options.target) {
+    this.log.info("TOOL", "Building only the " + this.options.target + " target, as specified from the command line.");
   }
   this._setupGNUStd(install);
   if (environment.isOSX) {

--- a/lib/es6/cMake.js
+++ b/lib/es6/cMake.js
@@ -256,8 +256,12 @@ CMake.prototype.ensureConfigured = async(function* () {
     }
 });
 
-CMake.prototype.getBuildCommand = function () {
-    return Bluebird.resolve(this.path + " --build \"" + this.workDir + "\" --config " + this.config);
+CMake.prototype.getBuildCommand = function() {
+    var command = this.path + " --build \"" + this.workDir + "\" --config " + this.config;
+    if (this.options.target) {
+        command += " --target " + this.options.target;
+    }
+    return Bluebird.resolve(command);
 };
 
 CMake.prototype.build = async(function* () {

--- a/lib/es6/toolset.js
+++ b/lib/es6/toolset.js
@@ -13,6 +13,7 @@ function Toolset(options) {
     this.options = options || {};
     this.targetOptions = new TargetOptions(this.options);
     this.generator = options.generator;
+    this.target = options.target;
     this.cCompilerPath = null;
     this.cppCompilerPath = null;
     this.compilerFlags = [];
@@ -128,6 +129,12 @@ Toolset.prototype.initializePosix = function (install) {
         this.compilerFlags.push("-w");
         this.linkerFlags.push("-undefined dynamic_lookup");
     }
+
+    // 4: Build target
+    if (this.options.target) {
+      this.log.info("TOOL", "Building only the " + this.options.target + " target, as specified from the command line.");
+    }
+
 };
 
 Toolset.prototype._setupGNUStd = function (install) {


### PR DESCRIPTION
Usage:

```bash
$ cmake-js build -T addon
```

Implements #91.