### PR TITLE
Obey CMAKE_GENERATOR env variable

### DIFF
--- a/bin/cmake-js
+++ b/bin/cmake-js
@@ -169,7 +169,7 @@ var options = {
     directory: argv.directory || null,
     debug: argv.debug,
     cmakePath: argv.c || null,
-    generator: argv.G,
+    generator: argv.G || process.env["CMAKE_GENERATOR"],
     target: argv.T,
     preferMake: argv.m,
     preferXcode: argv.x,


### PR DESCRIPTION
Hi There,
Currently cmake-js only allows setting the generator via the command line parameter `-G`. This is sometimes cumbersome to use.
This PR makes cmake-js honor the presence of an env variable called `CMAKE_GENERATOR`.

What do you think?
Thank you

