### PR TITLE
replace unzip with unzipper

### DIFF
--- a/lib/es6/downloader.js
+++ b/lib/es6/downloader.js
@@ -8,7 +8,7 @@ let zlib = require("zlib");
 let tar = require("tar");
 let fs = Bluebird.promisifyAll(require("fs-extra"));
 let _ = require("lodash");
-let unzip = require("unzip");
+let unzip = require("unzipper");
 let CMLog = require("./cmLog");
 
 function Downloader(options) {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "splitargs": "0",
     "tar": "^3.1.5",
     "traceur": "0.0.x",
-    "unzip": "^0.1.11",
+    "unzipper": "^0.8.13",
     "url-join": "0",
     "which": "^1.0.9",
     "yargs": "^3.6.0"


### PR DESCRIPTION
unzipper is maintained fork of unzip
installing unzipper does not produce scary npm warnings