### PR TITLE
remove incorrect initialization of npmConfigData to empty object

### DIFF
--- a/lib/es6/cMake.js
+++ b/lib/es6/cMake.js
@@ -188,7 +188,6 @@ CMake.prototype.getConfigureCommand = async(function* () {
     }
 
     // Load NPM config
-    npmConfigData = {};
     for (let key of _.keys(npmConfigData)) {
         let ukey = key.toUpperCase();
         if (_.startsWith(ukey, "CMAKE_")) {


### PR DESCRIPTION
This change "replace npmconf with rc (#119)"
```
let npmConfigData = require("rc")("npm");
```
in version 3.7.0 is breaking our builds , I fixed the code under node_modules and retested it on
npm version 5.7.1 looks good.

The variable was re-initialized to empty in the middle of the code and caused empty npmConfigData.

`npmConfigData = {}`



