### PR TITLE
Use a fully resolved path for `workDir`.

### DIFF
--- a/lib/es5/cMake.js
+++ b/lib/es5/cMake.js
@@ -20,7 +20,7 @@ function CMake(options) {
   this.log = new CMLog(this.options);
   this.dist = new Dist(this.options);
   this.projectRoot = path.resolve(this.options.directory || process.cwd());
-  this.workDir = this.options.out || path.join(this.projectRoot, "build");
+  this.workDir = path.resolve(this.options.out || path.join(this.projectRoot, "build"));
   this.config = this.options.debug ? "Debug" : "Release";
   this.buildDir = path.join(this.workDir, this.config);
   this._isAvailable = null;

--- a/lib/es6/cMake.js
+++ b/lib/es6/cMake.js
@@ -21,7 +21,7 @@ function CMake(options) {
     this.log = new CMLog(this.options);
     this.dist = new Dist(this.options);
     this.projectRoot = path.resolve(this.options.directory || process.cwd());
-    this.workDir = this.options.out || path.join(this.projectRoot, "build");
+    this.workDir = path.resolve(this.options.out || path.join(this.projectRoot, "build"));
     this.config = this.options.debug ? "Debug" : "Release";
     this.buildDir = path.join(this.workDir, this.config);
     this._isAvailable = null;


### PR DESCRIPTION
Otherwise, when attempting to specify a root output directory like
`--out ./build` build output will end up in `./build/build` for reasons
I don't fully understand. Using fully resolved paths is a good practice
in any case.