### PR TITLE
Remove disabling of warnings on OSX

### DIFF
--- a/lib/es6/toolset.js
+++ b/lib/es6/toolset.js
@@ -127,7 +127,6 @@ Toolset.prototype.initializePosix = function (install) {
         this.compilerFlags.push("-D_LARGEFILE_SOURCE");
         this.compilerFlags.push("-D_FILE_OFFSET_BITS=64");
         this.compilerFlags.push("-DBUILDING_NODE_EXTENSION");
-        this.compilerFlags.push("-w");
         this.linkerFlags.push("-undefined dynamic_lookup");
     }
 


### PR DESCRIPTION
This allows the underlying project to control compile-time
warnings instead of silencing them unconditionally.

See issue https://github.com/cmake-js/cmake-js/issues/132