### PR TITLE
Add case sensitive NPM config integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,20 +223,20 @@ For current user:
 npm config set cmake_<key> <value>
 ```
 
-CMake.js will set a variable named uppercase `"<key>"` to `<value>` (by using `-D<key>="<value>"` option). User's settings will **overwrite** globals.
+CMake.js will set a variable named `"<key>"` to `<value>` (by using `-D<key>="<value>"` option). User's settings will **overwrite** globals.
 
 #### Example:
 
 Enter at command prompt:
 
 ```
-npm config set cmake_bubu="kittyfck"
+npm config set cmake_BuBu="kittyfck"
 ```
 
 Then write to your CMakeLists.txt the following:
 
 ```cmake
-message (STATUS ${BUBU})
+message (STATUS ${BuBu})
 ```
 
 This will print during configure:

--- a/lib/es5/cMake.js
+++ b/lib/es5/cMake.js
@@ -260,10 +260,9 @@ CMake.prototype.getConfigureCommand = async($traceurRuntime.initGeneratorFunctio
             for ($__10 = void 0, $__9 = (_.keys(npmConfigData))[Symbol.iterator](); !($__12 = ($__10 = $__9.next()).done); $__12 = true) {
               key = $__10.value;
               {
-                ukey = key.toUpperCase();
-                if (_.startsWith(ukey, "CMAKE_")) {
+                if (_.startsWith(key, "cmake_")) {
                   s = {};
-                  sk = ukey.substr(6);
+                  sk = key.substr(6);
                   if (sk) {
                     s[sk] = npmConfigData[key];
                     if (s[sk]) {

--- a/lib/es6/cMake.js
+++ b/lib/es6/cMake.js
@@ -192,10 +192,9 @@ CMake.prototype.getConfigureCommand = async(function* () {
 
     // Load NPM config
     for (let key of _.keys(npmConfigData)) {
-        let ukey = key.toUpperCase();
-        if (_.startsWith(ukey, "CMAKE_")) {
+        if (_.startsWith(key, "cmake_")) {
             let s = {};
-            let sk = ukey.substr(6);
+            let sk = key.substr(6);
             if (sk) {
                 s[sk] = npmConfigData[key];
                 if (s[sk]) {


### PR DESCRIPTION
Trying to fix issue #150 

Not sure how everything works but it seems to be the only places where the NPM config is used.