### PR TITLE
:wrench: Support Electron v4

### DIFF
--- a/lib/es6/runtimePaths.js
+++ b/lib/es6/runtimePaths.js
@@ -79,7 +79,7 @@ let runtimePaths = {
                 name: "node.lib"
             }],
             tarPath: "node" + "-v" + targetOptions.runtimeVersion + ".tar.gz",
-            headerOnly: false
+            headerOnly: semver.gte(targetOptions.runtimeVersion, '>=4.0.0-alpha')
         };
     },
     get: function (targetOptions) {

--- a/lib/es6/runtimePaths.js
+++ b/lib/es6/runtimePaths.js
@@ -79,7 +79,7 @@ let runtimePaths = {
                 name: "node.lib"
             }],
             tarPath: "node" + "-v" + targetOptions.runtimeVersion + ".tar.gz",
-            headerOnly: semver.gte(targetOptions.runtimeVersion, '>=4.0.0-alpha')
+            headerOnly: semver.gte(targetOptions.runtimeVersion, '4.0.0-alpha')
         };
     },
     get: function (targetOptions) {


### PR DESCRIPTION
Electron 4 changed the header directory to use the 'headerOnly' format rather than the 'full' node checkout format.