### PR TITLE
Fix cmake generator

### DIFF
--- a/lib/es6/toolset.js
+++ b/lib/es6/toolset.js
@@ -177,14 +177,23 @@ Toolset.prototype._getTopSupportedVisualStudioGenerator = async(function*() {
     let result = null;
     for (let gen of list) {
         let found = /^visual studio (\d+)/i.exec(gen);
-        if (found) {
-            let ver = parseInt(found[1]);
-            if (ver > maxVer) {
-                if (yield vsDetect.isInstalled(ver + ".0")) {
-                    result = this.targetOptions.isX64 ? (gen + " Win64") : gen;
-                    maxVer = ver;
-                }
-            }
+        if (!found) {
+            continue;
+        }
+
+        let ver = parseInt(found[1]);
+        if (ver <= maxVer) {
+            continue;
+        }
+
+        const is64Bit = gen.endsWith("Win64");
+        if ((this.targetOptions.isX86 && is64Bit) || (this.targetOptions.isX64 && !is64Bit)) {
+            continue;
+        }
+
+        if (yield vsDetect.isInstalled(ver + ".0")) {
+            result = gen;
+            maxVer = ver;
         }
     }
     return result;


### PR DESCRIPTION
The output of `cmake -E capabilities` has `Win64` suffix, so we need not add it manually. Closes #160.

```
{
  "generators": [
    {
      "extraGenerators": [],
      "name": "Visual Studio 15 2017 Win64",
      "platformSupport": true,
      "toolsetSupport": true
    },
    {
      "extraGenerators": [],
      "name": "Visual Studio 15 2017",
      "platformSupport": true,
      "toolsetSupport": true
    },
    {
      "extraGenerators": [],
      "name": "Visual Studio 15 2017 ARM",
      "platformSupport": true,
      "toolsetSupport": true
    },
    {
      "extraGenerators": [],
      "name": "Visual Studio 14 2015",
      "platformSupport": true,
      "toolsetSupport": true
    },
    {
      "extraGenerators": [],
      "name": "Visual Studio 12 2013 Win64",
      "platformSupport": true,
      "toolsetSupport": true
    },
    {
      "extraGenerators": [],
      "name": "Visual Studio 14 2015 Win64",
      "platformSupport": true,
      "toolsetSupport": true
    },
    {
      "extraGenerators": [],
      "name": "Visual Studio 12 2013",
      "platformSupport": true,
      "toolsetSupport": true
    },
    {
      "extraGenerators": [
        "CodeBlocks",
        "CodeLite",
        "Sublime Text 2",
        "Kate",
        "Eclipse CDT4"
      ],
      "name": "MinGW Makefiles",
      "platformSupport": false,
      "toolsetSupport": false
    },
    {
      "extraGenerators": [],
      "name": "Visual Studio 12 2013 ARM",
      "platformSupport": true,
      "toolsetSupport": true
    },
    {
      "extraGenerators": [],
      "name": "Visual Studio 14 2015 ARM",
      "platformSupport": true,
      "toolsetSupport": true
    },
    {
      "extraGenerators": [],
      "name": "Visual Studio 11 2012",
      "platformSupport": true,
      "toolsetSupport": true
    },
    {
      "extraGenerators": [],
      "name": "Visual Studio 11 2012 ARM",
      "platformSupport": true,
      "toolsetSupport": true
    },
    {
      "extraGenerators": [
        "CodeBlocks",
        "CodeLite",
        "Sublime Text 2",
        "Kate",
        "Eclipse CDT4"
      ],
      "name": "Unix Makefiles",
      "platformSupport": false,
      "toolsetSupport": false
    },
    {
      "extraGenerators": [],
      "name": "Visual Studio 11 2012 Win64",
      "platformSupport": true,
      "toolsetSupport": true
    },
    {
      "extraGenerators": [],
      "name": "Visual Studio 10 2010 Win64",
      "platformSupport": true,
      "toolsetSupport": true
    },
    {
      "extraGenerators": [],
      "name": "Visual Studio 10 2010",
      "platformSupport": true,
      "toolsetSupport": true
    },
    {
      "extraGenerators": [],
      "name": "Visual Studio 10 2010 IA64",
      "platformSupport": true,
      "toolsetSupport": true
    },
    {
      "extraGenerators": [],
      "name": "Visual Studio 9 2008",
      "platformSupport": true,
      "toolsetSupport": false
    },
    {
      "extraGenerators": [],
      "name": "Visual Studio 9 2008 Win64",
      "platformSupport": true,
      "toolsetSupport": false
    },
    {
      "extraGenerators": [
        "CodeBlocks"
      ],
      "name": "NMake Makefiles JOM",
      "platformSupport": false,
      "toolsetSupport": false
    },
    {
      "extraGenerators": [],
      "name": "Visual Studio 9 2008 IA64",
      "platformSupport": true,
      "toolsetSupport": false
    },
    {
      "extraGenerators": [],
      "name": "MSYS Makefiles",
      "platformSupport": false,
      "toolsetSupport": false
    },
    {
      "extraGenerators": [],
      "name": "Borland Makefiles",
      "platformSupport": false,
      "toolsetSupport": false
    },
    {
      "extraGenerators": [
        "CodeBlocks",
        "CodeLite",
        "Sublime Text 2",
        "Kate",
        "Eclipse CDT4"
      ],
      "name": "NMake Makefiles",
      "platformSupport": false,
      "toolsetSupport": false
    },
    {
      "extraGenerators": [],
      "name": "Green Hills MULTI",
      "platformSupport": true,
      "toolsetSupport": true
    },
    {
      "extraGenerators": [
        "CodeBlocks",
        "CodeLite",
        "Sublime Text 2",
        "Kate",
        "Eclipse CDT4"
      ],
      "name": "Ninja",
      "platformSupport": false,
      "toolsetSupport": false
    },
    {
      "extraGenerators": [],
      "name": "Watcom WMake",
      "platformSupport": false,
      "toolsetSupport": false
    }
  ],
  "serverMode": true,
  "version": {
    "isDirty": false,
    "major": 3,
    "minor": 13,
    "patch": 2,
    "string": "3.13.2",
    "suffix": ""
  }
}
```