### PR TITLE
replacing hardcoded node-addon-api path with execute_command output

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,12 @@ and add it to the include directories of your *CMake* project file
 ```cmake
 
 # Include N-API wrappers
-target_include_directories(${PROJECT_NAME} PRIVATE "${CMAKE_SOURCE_DIR}/node_modules/node-addon-api")
+execute_process(COMMAND node -p "require('node-addon-api').include"
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE NODE_ADDON_API_DIR
+        )
+string(REPLACE "\"" "" NODE_ADDON_API_DIR ${NODE_ADDON_API_DIR})
+target_include_directories(${PROJECT_NAME} PRIVATE ${NODE_ADDON_API_DIR})
 
 ```
 


### PR DESCRIPTION
I do not think that the hard-coded path to the folder is a good solution. Especially if it is a multi-package repository like [lerna](https://github.com/lerna/lerna)