### PR TITLE
Fix visual c++ detection via vswhere

### DIFF
--- a/lib/es6/vsDetect.js
+++ b/lib/es6/vsDetect.js
@@ -15,18 +15,16 @@ let vsDetect = {
         return vsInstalled || vsvNextInstalled || buildToolsInstalled || foundByVSWhere;
     }),
     _isFoundByVSWhere: async(function* (version) {
-        // TODO: with auto download
-        /*
         let mainVer = version.split(".")[0];
-        let command = path.resolve("vswhere.exe");
+        let basePath = _.get(process.env, "ProgramFiles(x86)", _.get(process.env, "ProgramFiles"));
+        let command = path.resolve(basePath, "Microsoft Visual Studio", "Installer", "vswhere.exe");
         try {
-            let stdout = yield processHelpers.exec(command, ["-version", version]);
+            let stdout = yield processHelpers.exec(`"${command}" -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64`);
             return stdout && stdout.indexOf("installationVersion: " + mainVer) > 0;
         }
         catch (e) {
             _.noop(e);
         }
-        */
         return false;
     }),
     _isBuildToolsInstalled: async(function*(version) {


### PR DESCRIPTION
Implements vswhere detection as per https://github.com/cmake-js/cmake-js/issues/100#issuecomment-447800214 and [vswhere wiki](https://github.com/microsoft/vswhere/wiki/Find-VC)

Until now this has only been tested on a build server with VS build tools installed, but I will deploy this patch to a team with ~30 people in the coming weeks and report back how well it performed.