### PR TITLE
Expand the vswhere.exe query to detect partial VS installations (#183)

### DIFF
--- a/lib/es6/toolset.js
+++ b/lib/es6/toolset.js
@@ -218,7 +218,7 @@ Toolset.prototype._getTopSupportedVisualStudioGenerator = async(function*() {
 Toolset.prototype._getGeneratorFromVSWhere = async(function*() {
     let programFilesPath = _.get(process.env, "ProgramFiles(x86)", _.get(process.env, "ProgramFiles"));
     let vswhereCommand = path.resolve(programFilesPath, "Microsoft Visual Studio", "Installer", "vswhere.exe");
-    const vswhereOutput = yield processHelpers.exec(`"${vswhereCommand}" -property installationVersion`);
+    const vswhereOutput = yield processHelpers.exec(`"${vswhereCommand}" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationVersion`);
 
     if (!vswhereOutput) {
         return null;


### PR DESCRIPTION
Confirmed detection for fresh installs of:
- Build Tools 2019 via `choco install visualstudio2019-workload-vctools`
- VS 2019
- Build Tools 2017 via `choco install visualstudio2017-workload-vctools`
- NPM `windows-build-tools`