### PR TITLE
Use npmrc proxy and strict-ssl settings when downloading deps

### DIFF
--- a/lib/es6/downloader.js
+++ b/lib/es6/downloader.js
@@ -1,6 +1,7 @@
 "use strict";
 let Promise = require("bluebird");
 let crypto = require("crypto");
+let rc = require("rc");
 let request = require("request");
 let async = Promise.coroutine;
 let MemoryStream = require("memory-stream");
@@ -13,6 +14,8 @@ let CMLog = require("./cmLog");
 
 function Downloader(options) {
     this.options = options || {};
+    this.npmrc = rc('npm', {});
+
     this.log = new CMLog(this.options);
 }
 
@@ -23,8 +26,25 @@ Downloader.prototype.downloadToStream = function(url, stream, hash) {
         let length = 0;
         let done = 0;
         let lastPercent = 0;
+
+        let requestOptions = {
+            uri: url
+        };
+
+        if (this.npmrc.proxy) {
+            requestOptions.proxy = this.npmrc.proxy;
+        }
+
+        if (this.npmrc['https-proxy']) {
+            requestOptions.proxy = this.npmrc['https-proxy'];
+        }
+
+        if (this.npmrc['strict-ssl'] === false) {
+            requestOptions.strictSSL = false;
+        }
+
         request
-            .get(url)
+            .get(requestOptions)
             .on("error", function (err) {
                 reject(err);
             })


### PR DESCRIPTION
Allows those behind corp firewalls to download required dependencies