### PR TITLE
Handle installations with no vswhere.exe

### DIFF
--- a/lib/es6/toolset.js
+++ b/lib/es6/toolset.js
@@ -218,7 +218,15 @@ Toolset.prototype._getTopSupportedVisualStudioGenerator = async(function*() {
 Toolset.prototype._getGeneratorFromVSWhere = async(function*() {
     let programFilesPath = _.get(process.env, "ProgramFiles(x86)", _.get(process.env, "ProgramFiles"));
     let vswhereCommand = path.resolve(programFilesPath, "Microsoft Visual Studio", "Installer", "vswhere.exe");
-    const vswhereOutput = yield processHelpers.exec(`"${vswhereCommand}" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationVersion`);
+    let vswhereOutput = null;
+
+    try {
+        this.log.verbose("TOOL", `Looking for vswhere.exe at '${vswhereCommand}'.`)
+        vswhereOutput = yield processHelpers.exec(`"${vswhereCommand}" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationVersion`);
+    } catch (e) {
+        this.log.verbose("TOOL", "Could not find vswhere.exe (VS installation is probably older than 15.2).")
+        return null;
+    }
 
     if (!vswhereOutput) {
         return null;


### PR DESCRIPTION
Catch the `The system cannot find the path specified.` error seen in #186 or other errors that arise from the vswhere process. VS installations without vswhere.exe should fall back to the previous workflow as intended.