### PR TITLE
Auto-detect Visual Studio 2019 platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Options:
                          available (Posix)                             [boolean]
   -G, --generator        use specified generator                        [string]
   -t, --toolset          use specified toolset                          [string]
+  -A, --platform         use specified platform name                    [string]
   -T, --target           only build the specified target                [string]
   -C, --prefer-clang     use Clang compiler instead of default CMake compiler,
                          if available (Posix)                          [boolean]
@@ -281,6 +282,8 @@ This will print during configure:
 
 ### Runtimes
 
+If any of the `runtime`, `runtimeVersion`, or `arch` configuration parameters is not explicitly configured, sensible defaults will be auto-detected based on the JavaScript environment where CMake.js runs within.
+
 You can configure runtimes for compiling target for all depending CMake.js modules in an application. Define a `cmake-js` key in the application's root `package.json` file, eg.:
 
 ```json
@@ -304,7 +307,7 @@ Available settings:
 	- `nw`: nw.js
 	- `electron`: Electron
 - **runtimeVersion**: version of the application's target runtime, for example: `0.12.1`
-- **arch**: architecture of application's target runtime (eg: `x64`, `ia32`, `arm`). *Notice: on non-Windows systems the C++ toolset's architecture's gonna be used despite this setting. If you don't specify this on Windows, then architecture of the main node/io.js runtime is gonna be used, so you have to choose a matching nw.js runtime.*
+- **arch**: architecture of application's target runtime (eg: `x64`, `ia32`, `arm64`, `arm`). *Notice: on non-Windows systems the C++ toolset's architecture's gonna be used despite this setting. If you don't specify this on Windows, then architecture of the main node/io.js runtime is gonna be used, so you have to choose a matching nw.js runtime.*
 
 #### Runtime options in CMakeLists.txt
 
@@ -312,7 +315,7 @@ The actual node runtime parameters are detectable in CMakeLists.txt files, the f
 
 - **NODE_RUNTIME**: `"node"`, `"nw"`, `"electron"`
 - **NODE_RUNTIMEVERSION**: for example: `"0.12.1"`
-- **NODE_ARCH**: `"x64"`, `"ia32"`, `"arm"`
+- **NODE_ARCH**: `"x64"`, `"ia32"`, `"arm64"`, `"arm"`
 
 #### NW.js
 
@@ -406,7 +409,6 @@ and add it to the include directories of your *CMake* project file
 `CMakeLists.txt`:
 
 ```cmake
-
 # Include N-API wrappers
 execute_process(COMMAND node -p "require('node-addon-api').include"
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}

--- a/bin/cmake-js
+++ b/bin/cmake-js
@@ -102,6 +102,12 @@ var yargs = require("yargs")
             describe: "use specified toolset",
             type: "string"
         },
+        A: {
+            alias: "platform",
+            demand: false,
+            describe: "use specified platform name",
+            type: "string"
+        },
         T: {
             alias: "target",
             demand: false,
@@ -193,6 +199,7 @@ var options = {
     cmakePath: argv.c || null,
     generator: argv.G,
     toolset: argv.t,
+    platform: argv.A,
     target: argv.T,
     preferMake: argv.m,
     preferXcode: argv.x,

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+unreleased
+==========
+
+- Add support for "-A/--platform" option to make target platform selectable for Visual Studio 2019 generator: https://github.com/cmake-js/cmake-js/pull/201
+
 v6.0.0 - 30/09/19
 =================
 

--- a/lib/cMake.js
+++ b/lib/cMake.js
@@ -190,6 +190,9 @@ CMake.prototype.getConfigureCommand = async function () {
     if (this.toolset.generator) {
         command += " -G\"" + this.toolset.generator + "\"";
     }
+    if (this.toolset.platform) {
+        command += " -A\"" + this.toolset.platform + "\"";
+    }
     if (this.toolset.toolset) {
         command += " -T\"" + this.toolset.toolset + "\"";
     }

--- a/lib/toolset.js
+++ b/lib/toolset.js
@@ -171,6 +171,29 @@ Toolset.prototype.initializeWin = async function (install) {
             }
             this.linkerFlags.push("/SAFESEH:NO");
         }
+
+        // The CMake Visual Studio Generator does not support the Win64 or ARM suffix on
+        // the generator name. Instead the generator platform must be set explicitly via
+        // the platform parameter
+        if (!this.platform && this.generator.startsWith("Visual Studio 16")) {
+            switch(this.targetOptions.arch) {
+                case "ia32":
+                    this.platform = "Win32";
+                    break;
+                case "x64":
+                    this.platform = "x64";
+                    break;
+                case "arm":
+                    this.platform = "ARM";
+                    break;
+                case "arm64":
+                    this.platform = "ARM64";
+                    break;
+                default:
+                    this.log.warn("TOOL", "Unknown NodeJS architecture: " + this.targetOptions.arch);
+                    break;
+            }
+        }
     }
     else {
         throw new Error("There is no Visual C++ compiler installed. Install Visual C++ Build Toolset or Visual Studio.");

--- a/lib/toolset.js
+++ b/lib/toolset.js
@@ -15,6 +15,7 @@ function Toolset(options) {
     this.targetOptions = new TargetOptions(this.options);
     this.generator = options.generator;
     this.toolset = options.toolset;
+    this.platform = options.platform;
     this.target = options.target;
     this.cCompilerPath = options.cCompilerPath;
     this.cppCompilerPath = options.cppCompilerPath;


### PR DESCRIPTION
The CMake Visual Studio 2019 Generator does not support the Win64 or ARM suffix on the generator name. Instead the generator platform must be set explicitly via the platform parameter.

Before this patch the platform was not set at all which results in CMake picking the host architecture. This obviously leads to mismatches if a 32bit NodeJS is used on a 64bit Windows.

Right now the platform parameter is only applied for Visual Studio 16 because cmake-js does not specify a minimum CMake version. If at least CMake 3.1 (released December 2014) would be required the platform selection code could be made unconditional and thus forward-compatible with newer CMake Visual Studio generators.

Thanks to @WopsS for #177 which added platform parameter support.