### PR TITLE
mac addon build requires -std=c++11

### DIFF
--- a/lib/toolset.js
+++ b/lib/toolset.js
@@ -129,6 +129,7 @@ Toolset.prototype.initializePosix = function (install) {
         this.compilerFlags.push("-D_LARGEFILE_SOURCE");
         this.compilerFlags.push("-D_FILE_OFFSET_BITS=64");
         this.compilerFlags.push("-DBUILDING_NODE_EXTENSION");
+        this.compilerFlags.push("-std=c++11");
         this.linkerFlags.push("-undefined dynamic_lookup");
     }
 


### PR DESCRIPTION
It seems that through a refactoring of cmake-js, the mac build got broken because of missing `-std=c++11` as compiler flag (this flag was present in older versions of cmake-js).

Build errors would be shown like:
```
In file included from /Users/runner/runners/2.169.1/work/pa-opus-audio/pa-opus-audio/src/rehearse20.h:4:
/Users/runner/runners/2.169.1/work/pa-opus-audio/pa-opus-audio/node_modules/node-addon-api/napi.h:515:26: warning: deleted function definitions are a C++11 extension [-Wc++11-extensions]
      PropertyLValue() = delete;
                         ^
/Users/runner/runners/2.169.1/work/pa-opus-audio/pa-opus-audio/node_modules/node-addon-api/napi.h:701:18: error: no template named 'initializer_list' in namespace 'std'
      const std::initializer_list<PropertyDescriptor>& properties
            ~~~~~^
```

With this fix, the mac build works again.