### PR TITLE
Allows to specify custom build configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Options:
   -d, --directory        specify CMake project's directory (where CMakeLists.txt
                          located)                                       [string]
   -D, --debug            build debug configuration                     [boolean]
+  -C, --config           specify build configuration (Debug, RelWithDebInfo,
+                         Release), will ignore '--debug' if specified   [string]
   -c, --cmake-path       path of CMake executable                       [string]
   -m, --prefer-make      use Unix Makefiles even if Ninja is available (Posix)
                                                                        [boolean]

--- a/bin/cmake-js
+++ b/bin/cmake-js
@@ -66,6 +66,12 @@ var yargs = require("yargs")
             describe: "build debug configuration",
             type: "boolean"
         },
+        C: {
+            alias: "config",
+            demand: false,
+            describe: "specify build configuration (Debug, RelWithDebInfo, Release), will ignore '--debug' if specified",
+            type: "string"
+        },
         c: {
             alias: "cmake-path",
             demand: false,

--- a/lib/cMake.js
+++ b/lib/cMake.js
@@ -20,7 +20,7 @@ function CMake(options) {
     this.dist = new Dist(this.options);
     this.projectRoot = path.resolve(this.options.directory || process.cwd());
     this.workDir = path.resolve(this.options.out || path.join(this.projectRoot, "build"));
-    this.config = this.options.debug ? "Debug" : "Release";
+    this.config = this.options.config || this.options.debug ? "Debug" : "Release";
     this.buildDir = path.join(this.workDir, this.config);
     this._isAvailable = null;
     this.targetOptions = new TargetOptions(this.options);


### PR DESCRIPTION
This change allows user to specify custom build configuration types. resolves #108.

A new command flag `-C`/`--config` is added to enable users to pass custom build configuration type, which goes to `CMAKE_BUILD_TYPE` in Cmake.

The previous flag `--debug` is preserved for backward compatibility.