### PR TITLE
add environment check for azure build agent

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -17,7 +17,11 @@ let environment = module.exports = {
     runtime: isIOJS ? "iojs" : "node",
     runtimeVersion: process.versions.node,
     home: process.env[(os.platform() === "win32") ? "USERPROFILE" : "HOME"],
-    EOL: os.EOL
+    EOL: os.EOL,
+    isAzureBuildAgent: (os.platform() === "win32") && 
+                       process.env.AZURE_EXTENSION_DIR &&
+                       process.env.USERNAME && 
+                       process.env.USERNAME == "VssAdministrator"
 };
 
 Object.defineProperties(environment, {

--- a/lib/processHelpers.js
+++ b/lib/processHelpers.js
@@ -12,6 +12,10 @@ let processHelpers = {
             let args = splitargs(command);
             let name = args[0];
             args.splice(0, 1);
+            if (environment.isAzureBuildAgent) {
+                delete process.env.NPM_CONFIG_USERCONFIG;
+            }
+            
             let child = spawn(name, args, {stdio: options.silent ? "ignore" : "inherit"});
             let ended = false;
             child.on("error", function (e) {

--- a/lib/processHelpers.js
+++ b/lib/processHelpers.js
@@ -4,6 +4,7 @@ let splitargs = require("splitargs");
 let _ = require("lodash");
 let spawn = require("child_process").spawn;
 let exec = require("child_process").exec;
+let environment = require('./environment');
 
 let processHelpers = {
     run: function (command, options) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cmake-js",
-  "version": "5.4.0",
+  "version": "6.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "boost"
   ],
   "main": "lib",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "author": "Gábor Mező aka unbornchikken",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I was building on Azure and ran into a failure very much like this one: [MSBuild should sanitize environment block on startup](https://github.com/dotnet/msbuild/issues/5726). 

![duplicate_npm_config](https://user-images.githubusercontent.com/12236747/99569094-32df5200-299e-11eb-8934-974cc08382d3.png)
![resulting_failure](https://user-images.githubusercontent.com/12236747/99569119-3c68ba00-299e-11eb-974b-99b49a7db153.png)
