### PR TITLE
sanitize env vars for azure build agent

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -17,7 +17,11 @@ let environment = module.exports = {
     runtime: isIOJS ? "iojs" : "node",
     runtimeVersion: process.versions.node,
     home: process.env[(os.platform() === "win32") ? "USERPROFILE" : "HOME"],
-    EOL: os.EOL
+    EOL: os.EOL,
+    isAzureBuildAgent: (os.platform() === "win32") && 
+                       process.env.AZURE_EXTENSION_DIR &&
+                       process.env.USERNAME && 
+                       process.env.USERNAME == "VssAdministrator"
 };
 
 Object.defineProperties(environment, {

--- a/lib/processHelpers.js
+++ b/lib/processHelpers.js
@@ -4,6 +4,7 @@ let splitargs = require("splitargs");
 let _ = require("lodash");
 let spawn = require("child_process").spawn;
 let exec = require("child_process").exec;
+let environment = require('./environment');
 
 let processHelpers = {
     run: function (command, options) {
@@ -12,6 +13,13 @@ let processHelpers = {
             let args = splitargs(command);
             let name = args[0];
             args.splice(0, 1);
+            if (environment.isAzureBuildAgent) {
+                delete process.env.NPM_CONFIG_USERCONFIG;
+                const PATH = process.env.Path;
+                delete process.env.Path;
+                process.env.PATH = PATH;
+            }
+            
             let child = spawn(name, args, {stdio: options.silent ? "ignore" : "inherit"});
             let ended = false;
             child.on("error", function (e) {


### PR DESCRIPTION
Building for Windows on Azure wound up causing an issue very similar to this one: [MSBuild should sanitize environment block on startup](https://github.com/dotnet/msbuild/issues/5726).

The real problem is with MSBuild, but their team doesn't seem keen to resolve it. My project exposed two variables that needed help, but there could be more.
![duplicate_npm_config](https://user-images.githubusercontent.com/12236747/99586092-37fbcb80-29b5-11eb-8553-1e01d5c7b4da.png)
![duplicate_path_var](https://user-images.githubusercontent.com/12236747/99586093-38946200-29b5-11eb-9565-c3f929fa9c4e.png)
![resulting_failure](https://user-images.githubusercontent.com/12236747/99586094-38946200-29b5-11eb-9fd5-42d32fd331fb.png)
![resulting_failure_path](https://user-images.githubusercontent.com/12236747/99586095-392cf880-29b5-11eb-9dbf-13f60a735722.png)



