### PR TITLE
Don't use 'this' in static methods

### DIFF
--- a/lib/cMake.js
+++ b/lib/cMake.js
@@ -75,7 +75,7 @@ CMake.getGenerators = async function (options) {
             return capabilities.generators.map(x => x.name);
         }
         catch (error) {
-            this.log.verbose("TOOL", "Failed to query CMake capabilities (CMake is probably older than 3.7)");
+            new CMLog(options).log.verbose("TOOL", "Failed to query CMake capabilities (CMake is probably older than 3.7)");
         }
 
         // fall back to parsing help text


### PR DESCRIPTION
CMake.getGenerators is called as a static method. As such, it cannot
access instance members such as `this.log`. Instead, create a temporary
log object to write to if an error occurs.

This avoids the 'Cannot read property 'verbose' of undefined' errors
that otherwise occur as described in issue #167