### PR TITLE
Correctly handle spaces in paths

### DIFF
--- a/lib/cMake.js
+++ b/lib/cMake.js
@@ -70,7 +70,7 @@ CMake.getGenerators = async function (options) {
     if (CMake.isAvailable(options)) {
         // try parsing machine-readable capabilities (available since CMake 3.7)
         try {
-            let stdout = await processHelpers.exec((options.cmakePath || "cmake") + " -E capabilities");
+            let stdout = await processHelpers.execFile([options.cmakePath || "cmake", "-E", "capabilities"]);
             let capabilities = JSON.parse(stdout);
             return capabilities.generators.map(x => x.name);
         }
@@ -79,7 +79,7 @@ CMake.getGenerators = async function (options) {
         }
 
         // fall back to parsing help text
-        let stdout = await processHelpers.exec((options.cmakePath || "cmake") + " --help");
+        let stdout = await processHelpers.execFile([options.cmakePath || "cmake", "--help"]);
         let hasCr = stdout.includes("\r\n");
         let output = hasCr ? stdout.split("\r\n") : stdout.split("\n");
         let on = false;
@@ -118,8 +118,7 @@ CMake.prototype.verifyIfAvailable = function () {
 
 CMake.prototype.getConfigureCommand = async function () {
     // Create command:
-    let command = this.path;
-    command += " \"" + this.projectRoot + "\" --no-warn-unused-cli";
+    let command = [this.path, this.projectRoot, "--no-warn-unused-cli"];
 
     let D = [];
 
@@ -188,13 +187,13 @@ CMake.prototype.getConfigureCommand = async function () {
     await this.toolset.initialize(false);
 
     if (this.toolset.generator) {
-        command += " -G\"" + this.toolset.generator + "\"";
+        command.push("-G", this.toolset.generator);
     }
     if (this.toolset.platform) {
-        command += " -A\"" + this.toolset.platform + "\"";
+        command.push("-A", this.toolset.platform);
     }
     if (this.toolset.toolset) {
-        command += " -T\"" + this.toolset.toolset + "\"";
+        command.push("-T", this.toolset.toolset);
     }
     if (this.toolset.cppCompilerPath) {
         D.push({"CMAKE_CXX_COMPILER": this.toolset.cppCompilerPath});
@@ -226,10 +225,9 @@ CMake.prototype.getConfigureCommand = async function () {
         }
     }
 
-    command += " " +
-        D.map(function (p) {
-            return "-D" + _.keys(p)[0] + "=\"" + _.values(p)[0] + "\"";
-        }).join(" ");
+    command = command.concat(D.map(function (p) {
+            return "-D" + _.keys(p)[0] + "=" + _.values(p)[0];
+        }));
 
     return command;
 };
@@ -276,9 +274,9 @@ CMake.prototype.ensureConfigured = async function () {
 };
 
 CMake.prototype.getBuildCommand = function () {
-    var command = this.path + " --build \"" + this.workDir + "\" --config " + this.config;
+    var command = [this.path, "--build", this.workDir, "--config", this.config];
     if (this.options.target) {
-        command += " --target " + this.options.target;
+        command.push("--target", this.options.target);
     }
     return Promise.resolve(command);
 };
@@ -293,7 +291,7 @@ CMake.prototype.build = async function () {
 };
 
 CMake.prototype.getCleanCommand = function () {
-    return this.path + " -E remove_directory \"" + this.workDir + "\"";
+    return [this.path, "-E", "remove_directory", this.workDir];
 };
 
 CMake.prototype.clean = function () {

--- a/lib/processHelpers.js
+++ b/lib/processHelpers.js
@@ -3,16 +3,13 @@ let Promise = require("bluebird");
 let splitargs = require("splitargs");
 let _ = require("lodash");
 let spawn = require("child_process").spawn;
-let exec = require("child_process").exec;
+let execFile = require("child_process").execFile;
 
 let processHelpers = {
     run: function (command, options) {
         options = _.defaults(options, {silent: false});
         return new Promise(function (resolve, reject) {
-            let args = splitargs(command);
-            let name = args[0];
-            args.splice(0, 1);
-            let child = spawn(name, args, {stdio: options.silent ? "ignore" : "inherit"});
+            let child = spawn(command[0], command.slice(1), {stdio: options.silent ? "ignore" : "inherit"});
             let ended = false;
             child.on("error", function (e) {
                 if (!ended) {
@@ -33,9 +30,9 @@ let processHelpers = {
             });
         });
     },
-    exec: function(command) {
+    execFile: function(command) {
         return new Promise(function (resolve, reject) {
-            exec(command, function (err, stdout, stderr) {
+            execFile(command[0], command.slice(1), function (err, stdout, stderr) {
                 if (err) {
                     reject(new Error(err.message + "\n" + (stdout || stderr)));
                 }

--- a/lib/toolset.js
+++ b/lib/toolset.js
@@ -244,7 +244,7 @@ Toolset.prototype._getVersionFromVSWhere = async function () {
 
     try {
         this.log.verbose("TOOL", `Looking for vswhere.exe at '${vswhereCommand}'.`);
-        vswhereOutput = await processHelpers.exec(`"${vswhereCommand}" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationVersion`);
+        vswhereOutput = await processHelpers.execFile([vswhereCommand, "-latest", "-products", "*", "-requires", "Microsoft.VisualStudio.Component.VC.Tools.x86.x64", "-property", "installationVersion"]);
     }
     catch (e) {
         this.log.verbose("TOOL", "Could not find vswhere.exe (VS installation is probably older than 15.2).");

--- a/lib/vsDetect.js
+++ b/lib/vsDetect.js
@@ -19,7 +19,7 @@ let vsDetect = {
         let mainVer = version.split(".")[0];
         let command = path.resolve("vswhere.exe");
         try {
-            let stdout = yield processHelpers.exec(command, ["-version", version]);
+            let stdout = yield processHelpers.execFile([command, "-version", version]);
             return stdout && stdout.indexOf("installationVersion: " + mainVer) > 0;
         }
         catch (e) {
@@ -41,9 +41,9 @@ let vsDetect = {
             key = "HKLM\\SOFTWARE\\Classes\\Installer\\Dependencies\\Microsoft.VS.VisualCppBuildTools_x86_enu,v" + mainVer;
             testPhrase = "Visual C++";
         }
-        let command = "reg query \"" + key + "\"";
+        let command = ["reg", "query", "\"" + key + "\""];
         try {
-            let stdout = await processHelpers.exec(command);
+            let stdout = await processHelpers.execFile(command);
             return stdout && stdout.indexOf(testPhrase) > 0;
         }
         catch (e) {
@@ -55,9 +55,9 @@ let vsDetect = {
     _isVSInstalled: async function (version) {
         // On x64 this will look for x64 keys only, but if VS and compilers installed properly,
         // it will write it's keys to 64 bit registry as well.
-        let command = "reg query \"HKLM\\Software\\Microsoft\\VisualStudio\\" + version + "\"";
+        let command = ["reg", "query", "\"HKLM\\Software\\Microsoft\\VisualStudio\\" + version + "\""];
         try {
-            let stdout = await processHelpers.exec(command);
+            let stdout = await processHelpers.execFile(command);
             if (stdout) {
                 let lines = stdout.split("\r\n").filter(function (line) {
                     return line.length > 10;
@@ -75,9 +75,9 @@ let vsDetect = {
 
     _isVSvNextInstalled: async function (version) {
         let mainVer = version.split(".")[0];
-        let command = "reg query \"HKLM\\SOFTWARE\\Classes\\Installer\\Dependencies\\Microsoft.VisualStudio.MinShell.Msi,v" + mainVer + "\"";
+        let command = ["reg", "query", "\"HKLM\\SOFTWARE\\Classes\\Installer\\Dependencies\\Microsoft.VisualStudio.MinShell.Msi,v" + mainVer + "\""];
         try {
-            let stdout = await processHelpers.exec(command);
+            let stdout = await processHelpers.execFile(command);
             if (stdout) {
                 let lines = stdout.split("\r\n").filter(function (line) {
                     return line.length > 10;

--- a/tests/es6/testCases.js
+++ b/tests/es6/testCases.js
@@ -50,7 +50,7 @@ let testCases = {
         let buildSystem = new BuildSystem(options);
 
         let command = yield buildSystem.getConfigureCommand();
-        assert.notEqual(command.indexOf("-Dfoo=\"bar\""), -1, "custom options added");
+        assert.notEqual(command.indexOf("-Dfoo=bar"), -1, "custom options added");
     })
 };
 


### PR DESCRIPTION
Previously, cmake-js would fail if the cmake path contained spaces (See
issue #167). It would call exec() with a path that was not escaped or quoted,
and fail to run. If we fix that, then spawn fails for similar reasons. Update
both functions to just take the command line as an array of strings.