### PR TITLE
Add delayimp.lib as a linked library for windows builds

### DIFF
--- a/lib/cMake.js
+++ b/lib/cMake.js
@@ -174,6 +174,9 @@ CMake.prototype.getConfigureCommand = async function () {
     if (environment.isWin) {
         // Win
         let libs = this.dist.winLibs;
+
+        libs.push("delayimp.lib");
+
         if (libs.length) {
             D.push({"CMAKE_JS_LIB": libs.join(";")});
         }


### PR DESCRIPTION
Explicitly add delayimp.lib for windows environment as it seems as visual studio automagically adds it behind the scenes and other generators (e.g. Ninja) won't build successfully without it. This is discussed in https://github.com/cmake-js/cmake-js/issues/113 