### PR TITLE
handle case when microsoft barfs on itself

### DIFF
--- a/lib/processHelpers.js
+++ b/lib/processHelpers.js
@@ -9,6 +9,7 @@ let processHelpers = {
     run: function (command, options) {
         options = _.defaults(options, {silent: false});
         return new Promise(function (resolve, reject) {
+            if (process.env.Path && process.env.PATH) delete process.env.Path;
             let child = spawn(command[0], command.slice(1), {stdio: options.silent ? "ignore" : "inherit"});
             let ended = false;
             child.on("error", function (e) {


### PR DESCRIPTION
Fixes this issue:
https://github.com/cmake-js/cmake-js/issues/232

Solves the intent of this PR:
https://github.com/cmake-js/cmake-js/pull/225

The culprit is Microsoft - they decided they "wontfix"
https://github.com/dotnet/msbuild/issues/5726

Basically a default Windows 10 environment has a variable called Path (note the case). Some how in the node process this gets duped as PATH. Microsoft sees two path's in their environment and crashes.