### PR TITLE
Convert var/let to let/const 

### DIFF
--- a/bin/cmake-js
+++ b/bin/cmake-js
@@ -1,17 +1,17 @@
 #!/usr/bin/env node
 "use strict";
 
-var log = require("npmlog");
-var _ = require("lodash");
-var BuildSystem = require("../").BuildSystem;
-var util = require("util");
-var version = require("../package").version;
-var logLevels = ["silly", "verbose", "info", "http", "warn", "error"];
+const log = require("npmlog");
+const _ = require("lodash");
+const BuildSystem = require("../").BuildSystem;
+const util = require("util");
+const version = require("../package").version;
+const logLevels = ["silly", "verbose", "info", "http", "warn", "error"];
 
-var npmConfigData = require("rc")("npm");
-for (var key of _.keys(npmConfigData)) {
+const npmConfigData = require("rc")("npm");
+for (const key of _.keys(npmConfigData)) {
     if (_.startsWith(key, "cmake_js_")) {
-        var option = key.substr(9);
+        const option = key.substr(9);
         if (option.length === 1) {
             process.argv.push("-" + option);
         }
@@ -26,7 +26,7 @@ for (var key of _.keys(npmConfigData)) {
 
 console.log(process.argv);
 
-var yargs = require("yargs")
+const yargs = require("yargs")
     .usage("CMake.js " + version + "\n\nUsage: $0 [<command>] [options]")
     .version(function () {
         return version;
@@ -164,7 +164,7 @@ var yargs = require("yargs")
           type: "string"
         }
     });
-var argv = yargs.argv;
+const argv = yargs.argv;
 
 // If help, then print and exit:
 
@@ -186,14 +186,14 @@ log.silly("CON", util.inspect(argv));
 log.verbose("CON", "Parsing arguments");
 
 // Extract custom cMake options
-var customOptions = {};
+const customOptions = {};
 _.keys(argv).forEach(function (key) {
     if (argv[key] && _.startsWith(key, "CD")) {
         customOptions[key.substr(2)] = argv[key];
     }
 });
 
-var options = {
+const options = {
     directory: argv.directory || null,
     debug: argv.debug,
     cmakePath: argv.c || null,
@@ -218,11 +218,11 @@ var options = {
 log.verbose("CON", "options:");
 log.verbose("CON", util.inspect(options));
 
-var command = _.first(argv._) || "build";
+const command = _.first(argv._) || "build";
 
 log.verbose("CON", "Running command: " + command);
 
-var buildSystem = new BuildSystem(options);
+const buildSystem = new BuildSystem(options);
 
 function ifCommand(c, f) {
     if (c === command) {
@@ -278,7 +278,7 @@ function compile() {
     exitOnError(buildSystem.compile());
 }
 
-var done = ifCommand("install", install);
+let done = ifCommand("install", install);
 done = done || ifCommand("configure", configure);
 done = done || ifCommand("print-configure", printConfigure);
 done = done || ifCommand("build", build);

--- a/lib/appCMakeJSConfig.js
+++ b/lib/appCMakeJSConfig.js
@@ -1,12 +1,12 @@
 "use strict";
-let path = require("path");
-let _ = require("lodash");
+const path = require("path");
+const _ = require("lodash");
 
 function getConfig(lookPath, log) {
-    let pjsonPath = path.join(lookPath, "package.json");
+    const pjsonPath = path.join(lookPath, "package.json");
     log.silly("CFG", "Looking for package.json in: '" + pjsonPath + "'.");
     try {
-        let json = require(pjsonPath);
+        const json = require(pjsonPath);
         log.silly("CFG", "Loaded:\n" + JSON.stringify(json));
         if (_.isPlainObject(json) && _.isPlainObject(json["cmake-js"])) {
             log.silly("CFG", "Config found.");
@@ -35,7 +35,7 @@ module.exports = function (projectPath, log) {
         }
         try {
             log.silly("CFG", "Looking for parent path.");
-            let lastPath = currPath;
+            const lastPath = currPath;
             currPath = path.normalize(path.join(currPath, ".."));
             if (lastPath === currPath) {
                 currPath = null; // root

--- a/lib/buildSystem.js
+++ b/lib/buildSystem.js
@@ -1,17 +1,17 @@
 "use strict";
-let CMake = require("./cMake");
-let Dist = require("./dist");
-let CMLog = require("./cmLog");
-let appCMakeJSConfig = require("./appCMakeJSConfig");
-let path = require("path");
-let _ = require("lodash");
-let Toolset = require("./toolset");
+const CMake = require("./cMake");
+const Dist = require("./dist");
+const CMLog = require("./cmLog");
+const appCMakeJSConfig = require("./appCMakeJSConfig");
+const path = require("path");
+const _ = require("lodash");
+const Toolset = require("./toolset");
 
 function BuildSystem(options) {
     this.options = options || {};
     this.options.directory = path.resolve(this.options.directory || process.cwd());
     this.log = new CMLog(this.options);
-    let appConfig = appCMakeJSConfig(this.options.directory, this.log);
+    const appConfig = appCMakeJSConfig(this.options.directory, this.log);
     if (_.isPlainObject(appConfig)) {
         if (_.keys(appConfig).length) {
             this.log.verbose("CFG", "Applying CMake.js config from root package.json:");

--- a/lib/cMake.js
+++ b/lib/cMake.js
@@ -274,7 +274,7 @@ CMake.prototype.ensureConfigured = async function () {
 };
 
 CMake.prototype.getBuildCommand = function () {
-    var command = [this.path, "--build", this.workDir, "--config", this.config];
+    const command = [this.path, "--build", this.workDir, "--config", this.config];
     if (this.options.target) {
         command.push("--target", this.options.target);
     }

--- a/lib/cMake.js
+++ b/lib/cMake.js
@@ -1,18 +1,18 @@
 "use strict";
-let splitargs = require("splitargs");
-let which = require("which");
-let fs = require("fs-extra");
-let path = require("path");
-let _ = require("lodash");
-let environment = require("./environment");
-let Dist = require("./dist");
-let CMLog = require("./cmLog");
-let vsDetect = require("./vsDetect");
-let TargetOptions = require("./targetOptions");
-let processHelpers = require("./processHelpers");
-let locateNAN = require("./locateNAN");
-let npmConfigData = require("rc")("npm");
-let Toolset = require("./toolset");
+const splitargs = require("splitargs");
+const which = require("which");
+const fs = require("fs-extra");
+const path = require("path");
+const _ = require("lodash");
+const environment = require("./environment");
+const Dist = require("./dist");
+const CMLog = require("./cmLog");
+const vsDetect = require("./vsDetect");
+const TargetOptions = require("./targetOptions");
+const processHelpers = require("./processHelpers");
+const locateNAN = require("./locateNAN");
+const npmConfigData = require("rc")("npm");
+const Toolset = require("./toolset");
 
 function CMake(options) {
     this.options = options || {};
@@ -49,7 +49,7 @@ CMake.isAvailable = function (options) {
     options = options || {};
     try {
         if (options.cmakePath) {
-            let stat = fs.lstatSync(options.cmakePath);
+            const stat = fs.lstatSync(options.cmakePath);
             return !stat.isDirectory();
         }
         else {
@@ -64,14 +64,14 @@ CMake.isAvailable = function (options) {
 };
 
 CMake.getGenerators = async function (options) {
-    let arch = " [arch]";
+    const arch = " [arch]";
     options = options || {};
-    let gens = [];
+    const gens = [];
     if (CMake.isAvailable(options)) {
         // try parsing machine-readable capabilities (available since CMake 3.7)
         try {
-            let stdout = await processHelpers.execFile([options.cmakePath || "cmake", "-E", "capabilities"]);
-            let capabilities = JSON.parse(stdout);
+            const stdout = await processHelpers.execFile([options.cmakePath || "cmake", "-E", "capabilities"]);
+            const capabilities = JSON.parse(stdout);
             return capabilities.generators.map(x => x.name);
         }
         catch (error) {
@@ -79,13 +79,13 @@ CMake.getGenerators = async function (options) {
         }
 
         // fall back to parsing help text
-        let stdout = await processHelpers.execFile([options.cmakePath || "cmake", "--help"]);
-        let hasCr = stdout.includes("\r\n");
-        let output = hasCr ? stdout.split("\r\n") : stdout.split("\n");
+        const stdout = await processHelpers.execFile([options.cmakePath || "cmake", "--help"]);
+        const hasCr = stdout.includes("\r\n");
+        const output = hasCr ? stdout.split("\r\n") : stdout.split("\n");
         let on = false;
         output.forEach(function (line, i) {
             if (on) {
-                let parts = line.split("=");
+                const parts = line.split("=");
                 if ((parts.length === 2 && parts[0].trim()) ||
                     (parts.length === 1 && i !== output.length - 1 && output[i + 1].trim()[0] === "=")) {
                     let gen = parts[0].trim();
@@ -120,7 +120,7 @@ CMake.prototype.getConfigureCommand = async function () {
     // Create command:
     let command = [this.path, this.projectRoot, "--no-warn-unused-cli"];
 
-    let D = [];
+    const D = [];
 
     // CMake.js watermark
     D.push({"CMAKE_JS_VERSION": environment.moduleVersion});
@@ -140,14 +140,14 @@ CMake.prototype.getConfigureCommand = async function () {
         incPaths = [path.join(this.dist.internalPath, "/include/node")];
     }
     else {
-        let nodeH = path.join(this.dist.internalPath, "/src");
-        let v8H = path.join(this.dist.internalPath, "/deps/v8/include");
-        let uvH = path.join(this.dist.internalPath, "/deps/uv/include");
+        const nodeH = path.join(this.dist.internalPath, "/src");
+        const v8H = path.join(this.dist.internalPath, "/deps/v8/include");
+        const uvH = path.join(this.dist.internalPath, "/deps/uv/include");
         incPaths = [nodeH, v8H, uvH];
     }
 
     // NAN
-    let nanH = await locateNAN(this.projectRoot);
+    const nanH = await locateNAN(this.projectRoot);
     if (nanH) {
         incPaths.push(nanH);
     }
@@ -156,9 +156,9 @@ CMake.prototype.getConfigureCommand = async function () {
     D.push({"CMAKE_JS_INC": incPaths.join(";")});
 
     // Sources:
-    let srcPaths = [];
+    const srcPaths = [];
     if (environment.isWin) {
-        let delayHook = path.normalize(path.join(__dirname, 'cpp', 'win_delay_load_hook.cc'));
+        const delayHook = path.normalize(path.join(__dirname, 'cpp', 'win_delay_load_hook.cc'));
 
         srcPaths.push(delayHook.replace(/\\/gm, '/'));
     }
@@ -172,14 +172,14 @@ CMake.prototype.getConfigureCommand = async function () {
 
     if (environment.isWin) {
         // Win
-        let libs = this.dist.winLibs;
+        const libs = this.dist.winLibs;
         if (libs.length) {
             D.push({"CMAKE_JS_LIB": libs.join(";")});
         }
     }
 
     // Custom options
-    for (let k of _.keys(this.cMakeOptions)) {
+    for (const k of _.keys(this.cMakeOptions)) {
         D.push({[k]: this.cMakeOptions[k]});
     }
 
@@ -212,10 +212,10 @@ CMake.prototype.getConfigureCommand = async function () {
     }
 
     // Load NPM config
-    for (let key of _.keys(npmConfigData)) {
+    for (const key of _.keys(npmConfigData)) {
         if (_.startsWith(key, "cmake_")) {
-            let s = {};
-            let sk = key.substr(6);
+            const s = {};
+            const sk = key.substr(6);
             if (sk) {
                 s[sk] = npmConfigData[key];
                 if (s[sk]) {
@@ -236,8 +236,8 @@ CMake.prototype.configure = async function () {
     this.verifyIfAvailable();
 
     this.log.info("CMD", "CONFIGURE");
-    let listPath = path.join(this.projectRoot, "CMakeLists.txt");
-    let command = await this.getConfigureCommand();
+    const listPath = path.join(this.projectRoot, "CMakeLists.txt");
+    const command = await this.getConfigureCommand();
 
     try {
         await fs.lstat(listPath);
@@ -253,7 +253,7 @@ CMake.prototype.configure = async function () {
         _.noop(e);
     }
 
-    let cwd = process.cwd();
+    const cwd = process.cwd();
     process.chdir(this.workDir);
     try {
         await this._run(command);
@@ -285,7 +285,7 @@ CMake.prototype.build = async function () {
     this.verifyIfAvailable();
 
     await this.ensureConfigured();
-    let buildCommand = await this.getBuildCommand();
+    const buildCommand = await this.getBuildCommand();
     this.log.info("CMD", "BUILD");
     await this._run(buildCommand);
 };

--- a/lib/cmLog.js
+++ b/lib/cmLog.js
@@ -1,5 +1,5 @@
 "use strict";
-let log = require("npmlog");
+const log = require("npmlog");
 
 function CMLog(options) {
     this.options = options || {};

--- a/lib/dist.js
+++ b/lib/dist.js
@@ -1,16 +1,16 @@
 "use strict";
-let environment = require("./environment");
-let path = require("path");
-let urljoin = require("url-join");
-let fs = require("fs-extra");
-let _ = require("lodash");
-let CMLog = require("./cmLog");
-let TargetOptions = require("./targetOptions");
-let runtimePaths = require("./runtimePaths");
-let Downloader = require("./downloader");
+const environment = require("./environment");
+const path = require("path");
+const urljoin = require("url-join");
+const fs = require("fs-extra");
+const _ = require("lodash");
+const CMLog = require("./cmLog");
+const TargetOptions = require("./targetOptions");
+const runtimePaths = require("./runtimePaths");
+const Downloader = require("./downloader");
 
 function testSum(sums, sum, fPath) {
-    let serverSum = _.first(sums.filter(function (s) {
+    const serverSum = _.first(sums.filter(function (s) {
         return s.getPath === fPath;
     }));
     if (serverSum && serverSum.sum === sum) {
@@ -60,7 +60,7 @@ Object.defineProperties(Dist.prototype, {
                     }
                 }
                 if (environment.isWin) {
-                    for (let libPath of this.winLibs) {
+                    for (const libPath of this.winLibs) {
                         stat = getStat(libPath);
                         libs = libs && stat.isFile();
                     }
@@ -83,9 +83,9 @@ Object.defineProperties(Dist.prototype, {
     },
     winLibs: {
         get: function () {
-            let libs = runtimePaths.get(this.targetOptions).winLibs;
-            let result = [];
-            for (let lib of libs) {
+            const libs = runtimePaths.get(this.targetOptions).winLibs;
+            const result = [];
+            for (const lib of libs) {
                 result.push(path.join(this.internalPath, lib.dir, lib.name));
             }
             return result;
@@ -106,22 +106,22 @@ Dist.prototype.ensureDownloaded = async function () {
 };
 
 Dist.prototype.download = async function () {
-    let log = this.log;
+    const log = this.log;
     log.info("DIST", "Downloading distribution files.");
     await fs.ensureDir(this.internalPath);
-    let sums = await this._downloadShaSums();
+    const sums = await this._downloadShaSums();
     await Promise.all([this._downloadLibs(sums), this._downloadTar(sums)]);
 };
 
 Dist.prototype._downloadShaSums = async function () {
     if (this.targetOptions.runtime === "node" || this.targetOptions.runtime === "iojs") {
-        let sumUrl = urljoin(this.externalPath, "SHASUMS256.txt");
-        let log = this.log;
+        const sumUrl = urljoin(this.externalPath, "SHASUMS256.txt");
+        const log = this.log;
         log.http("DIST", "\t- " + sumUrl);
         return (await this.downloader.downloadString(sumUrl))
             .split("\n")
             .map(function (line) {
-                let parts = line.split(/\s+/);
+                const parts = line.split(/\s+/);
                 return {
                     getPath: parts[1],
                     sum: parts[0]
@@ -137,13 +137,13 @@ Dist.prototype._downloadShaSums = async function () {
 };
 
 Dist.prototype._downloadTar = async function (sums) {
-    let log = this.log;
-    let self = this;
-    let tarLocalPath = runtimePaths.get(self.targetOptions).tarPath;
-    let tarUrl = urljoin(self.externalPath, tarLocalPath);
+    const log = this.log;
+    const self = this;
+    const tarLocalPath = runtimePaths.get(self.targetOptions).tarPath;
+    const tarUrl = urljoin(self.externalPath, tarLocalPath);
     log.http("DIST", "\t- " + tarUrl);
 
-    let sum = await this.downloader.downloadTgz(tarUrl, {
+    const sum = await this.downloader.downloadTgz(tarUrl, {
         hash: sums ? "sha256" : null,
         cwd: self.internalPath,
         strip: 1,
@@ -151,7 +151,7 @@ Dist.prototype._downloadTar = async function (sums) {
             if (entryPath === self.internalPath) {
                 return true;
             }
-            let ext = path.extname(entryPath);
+            const ext = path.extname(entryPath);
             return ext && ext.toLowerCase() === ".h";
         }
     });

--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -1,14 +1,14 @@
 "use strict";
-let Promise = require("bluebird");
-let crypto = require("crypto");
-let axios = require("axios");
-let MemoryStream = require("memory-stream");
-let zlib = require("zlib");
-let tar = require("tar");
-let fs = require("fs");
-let _ = require("lodash");
-let unzip = require("unzipper");
-let CMLog = require("./cmLog");
+const Promise = require("bluebird");
+const crypto = require("crypto");
+const axios = require("axios");
+const MemoryStream = require("memory-stream");
+const zlib = require("zlib");
+const tar = require("tar");
+const fs = require("fs");
+const _ = require("lodash");
+const unzip = require("unzipper");
+const CMLog = require("./cmLog");
 
 function Downloader(options) {
     this.options = options || {};
@@ -16,8 +16,8 @@ function Downloader(options) {
 }
 
 Downloader.prototype.downloadToStream = function(url, stream, hash) {
-    let self = this;
-    let shasum = hash ? crypto.createHash(hash) : null;
+    const self = this;
+    const shasum = hash ? crypto.createHash(hash) : null;
     return new Promise(function (resolve, reject) {
         let length = 0;
         let done = 0;
@@ -43,13 +43,13 @@ Downloader.prototype.downloadToStream = function(url, stream, hash) {
                             lastPercent = percent;
                         }
                     }
-                })
+                });
 
-                response.data.pipe(stream)
+                response.data.pipe(stream);
             })
             .catch(function (err) {
                 reject(err);
-            })
+            });
 
         stream.once("error", function (err) {
             reject(err);
@@ -62,7 +62,7 @@ Downloader.prototype.downloadToStream = function(url, stream, hash) {
 };
 
 Downloader.prototype.downloadString = async function (url) {
-    let result = new MemoryStream();
+    const result = new MemoryStream();
     await this.downloadToStream(url, result);
     return result.toString();
 };
@@ -71,8 +71,8 @@ Downloader.prototype.downloadFile = async function (url, options) {
     if (_.isString(options)) {
         options.path = options;
     }
-    let result = fs.createWriteStream(options.path);
-    let sum = await this.downloadToStream(url, result, options.hash);
+    const result = fs.createWriteStream(options.path);
+    const sum = await this.downloadToStream(url, result, options.hash);
     this.testSum(url, sum, options);
     return sum;
 };
@@ -81,10 +81,10 @@ Downloader.prototype.downloadTgz = async function (url, options) {
     if (_.isString(options)) {
         options.cwd = options;
     }
-    let gunzip = zlib.createGunzip();
-    let extractor = tar.extract(options);
+    const gunzip = zlib.createGunzip();
+    const extractor = tar.extract(options);
     gunzip.pipe(extractor);
-    let sum =  await this.downloadToStream(url, gunzip, options.hash);
+    const sum =  await this.downloadToStream(url, gunzip, options.hash);
     this.testSum(url, sum, options);
     return sum;
 };
@@ -93,8 +93,8 @@ Downloader.prototype.downloadZip = async function (url, options) {
     if (_.isString(options)) {
         options.path = options;
     }
-    let extractor = new unzip.Extract(options);
-    let sum =  await this.downloadToStream(url, extractor, options.hash);
+    const extractor = new unzip.Extract(options);
+    const sum =  await this.downloadToStream(url, extractor, options.hash);
     this.testSum(url, sum, options);
     return sum;
 };

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -1,10 +1,10 @@
 "use strict";
-let os = require("os");
-let isIOJS = require("is-iojs");
-let which = require("which");
-let _ = require("lodash");
+const os = require("os");
+const isIOJS = require("is-iojs");
+const which = require("which");
+const _ = require("lodash");
 
-let environment = module.exports = {
+const environment = module.exports = {
     moduleVersion: require("../package.json").version,
     platform: os.platform(),
     isWin: os.platform() === "win32",

--- a/lib/locateNAN.js
+++ b/lib/locateNAN.js
@@ -1,12 +1,12 @@
 "use strict";
-let fs = require("fs-extra");
-let path = require("path");
-let _ = require("lodash");
+const fs = require("fs-extra");
+const path = require("path");
+const _ = require("lodash");
 
-let isNANModule = async function (dir) {
-    let h = path.join(dir, "nan.h");
+const isNANModule = async function (dir) {
+    const h = path.join(dir, "nan.h");
     try {
-        let stat = await fs.stat(h);
+        const stat = await fs.stat(h);
         return stat.isFile();
     }
     catch (e) {
@@ -15,9 +15,9 @@ let isNANModule = async function (dir) {
     }
 };
 
-let isNodeJSProject = async function (dir) {
-    let pjson = path.join(dir, "package.json");
-    let node_modules = path.join(dir, "node_modules");
+const isNodeJSProject = async function (dir) {
+    const pjson = path.join(dir, "package.json");
+    const node_modules = path.join(dir, "node_modules");
     try {
         let stat = await fs.stat(pjson);
         if (stat.isFile()) {
@@ -34,7 +34,7 @@ let isNodeJSProject = async function (dir) {
     return false;
 };
 
-let locateNAN = module.exports = async function (projectRoot) {
+const locateNAN = module.exports = async function (projectRoot) {
     if (locateNAN.__projectRoot) {
         projectRoot = locateNAN.__projectRoot;
     }
@@ -42,7 +42,7 @@ let locateNAN = module.exports = async function (projectRoot) {
     if (!result) {
         return null;
     }
-    let nanModulePath = path.join(projectRoot, "node_modules", "nan");
+    const nanModulePath = path.join(projectRoot, "node_modules", "nan");
     result = await isNANModule(nanModulePath);
     if (result) {
         return nanModulePath;
@@ -53,8 +53,8 @@ let locateNAN = module.exports = async function (projectRoot) {
 };
 
 function goUp(dir) {
-    let items = dir.split(path.sep);
-    let scopeItem = items[items.length - 2];
+    const items = dir.split(path.sep);
+    const scopeItem = items[items.length - 2];
     if (scopeItem && scopeItem[0] === "@") {
         // skip scope
         dir = path.join(dir, "..");

--- a/lib/processHelpers.js
+++ b/lib/processHelpers.js
@@ -1,15 +1,15 @@
 "use strict";
-let Promise = require("bluebird");
-let splitargs = require("splitargs");
-let _ = require("lodash");
-let spawn = require("child_process").spawn;
-let execFile = require("child_process").execFile;
+const Promise = require("bluebird");
+const splitargs = require("splitargs");
+const _ = require("lodash");
+const spawn = require("child_process").spawn;
+const execFile = require("child_process").execFile;
 
-let processHelpers = {
+const processHelpers = {
     run: function (command, options) {
         options = _.defaults(options, {silent: false});
         return new Promise(function (resolve, reject) {
-            let child = spawn(command[0], command.slice(1), {stdio: options.silent ? "ignore" : "inherit"});
+            const child = spawn(command[0], command.slice(1), {stdio: options.silent ? "ignore" : "inherit"});
             let ended = false;
             child.on("error", function (e) {
                 if (!ended) {

--- a/lib/runtimePaths.js
+++ b/lib/runtimePaths.js
@@ -1,13 +1,13 @@
 "use strict";
-let _ = require("lodash");
-let assert = require("assert");
-let semver = require("semver");
+const _ = require("lodash");
+const assert = require("assert");
+const semver = require("semver");
 
-let NODE_MIRROR = process.env.NVM_NODEJS_ORG_MIRROR || "https://nodejs.org/dist";
-let IOJS_MIRROR = process.env.NVM_IOJS_ORG_MIRROR || "https://iojs.org/dist";
-let ELECTRON_MIRROR = process.env.ELECTRON_MIRROR || "https://atom.io/download/atom-shell";
+const NODE_MIRROR = process.env.NVM_NODEJS_ORG_MIRROR || "https://nodejs.org/dist";
+const IOJS_MIRROR = process.env.NVM_IOJS_ORG_MIRROR || "https://iojs.org/dist";
+const ELECTRON_MIRROR = process.env.ELECTRON_MIRROR || "https://atom.io/download/atom-shell";
 
-let runtimePaths = {
+const runtimePaths = {
     node: function (targetOptions) {
         if (semver.lt(targetOptions.runtimeVersion, "4.0.0")) {
             return {
@@ -85,8 +85,8 @@ let runtimePaths = {
     get: function (targetOptions) {
         assert(_.isObject(targetOptions));
 
-        let runtime = targetOptions.runtime;
-        let func = runtimePaths[runtime];
+        const runtime = targetOptions.runtime;
+        const func = runtimePaths[runtime];
         let paths;
         if (_.isFunction(func) && _.isPlainObject(paths = func(targetOptions))) {
             return paths;

--- a/lib/targetOptions.js
+++ b/lib/targetOptions.js
@@ -1,7 +1,7 @@
 "use strict";
 
-let environment = require("./environment");
-let _ = require("lodash");
+const environment = require("./environment");
+const _ = require("lodash");
 
 function TargetOptions(options) {
     this.options = options || {};

--- a/lib/toolset.js
+++ b/lib/toolset.js
@@ -1,14 +1,14 @@
 "use strict";
-let Promise = require("bluebird");
-let async = Promise.coroutine;
-let _ = require("lodash");
-let TargetOptions = require("./targetOptions");
-let environment = require("./environment");
-let assert = require("assert");
-let vsDetect = require("./vsDetect");
-let path = require("path");
-let CMLog = require("./cmLog");
-let processHelpers = require("./processHelpers");
+const Promise = require("bluebird");
+const async = Promise.coroutine;
+const _ = require("lodash");
+const TargetOptions = require("./targetOptions");
+const environment = require("./environment");
+const assert = require("assert");
+const vsDetect = require("./vsDetect");
+const path = require("path");
+const CMLog = require("./cmLog");
+const processHelpers = require("./processHelpers");
 
 function Toolset(options) {
     this.options = options || {};
@@ -156,7 +156,7 @@ Toolset.prototype.initializeWin = async function (install) {
         }
         return;
     }
-    let topVS = await this._getTopSupportedVisualStudioGenerator();
+    const topVS = await this._getTopSupportedVisualStudioGenerator();
     if (topVS) {
         if (install) {
             this.log.info("TOOL", `Using ${topVS} generator.`);
@@ -201,21 +201,21 @@ Toolset.prototype.initializeWin = async function (install) {
 };
 
 Toolset.prototype._getTopSupportedVisualStudioGenerator = async function () {
-    let CMake = require("./cMake");
+    const CMake = require("./cMake");
     assert(environment.isWin);
 
-    let vswhereVersion = await this._getVersionFromVSWhere();
+    const vswhereVersion = await this._getVersionFromVSWhere();
 
-    let list = await CMake.getGenerators(this.options);
+    const list = await CMake.getGenerators(this.options);
     let maxVer = 0;
     let result = null;
-    for (let gen of list) {
-        let found = /^visual studio (\d+)/i.exec(gen);
+    for (const gen of list) {
+        const found = /^visual studio (\d+)/i.exec(gen);
         if (!found) {
             continue;
         }
 
-        let ver = parseInt(found[1]);
+        const ver = parseInt(found[1]);
         if (ver <= maxVer) {
             continue;
         }
@@ -238,8 +238,8 @@ Toolset.prototype._getTopSupportedVisualStudioGenerator = async function () {
 };
 
 Toolset.prototype._getVersionFromVSWhere = async function () {
-    let programFilesPath = _.get(process.env, "ProgramFiles(x86)", _.get(process.env, "ProgramFiles"));
-    let vswhereCommand = path.resolve(programFilesPath, "Microsoft Visual Studio", "Installer", "vswhere.exe");
+    const programFilesPath = _.get(process.env, "ProgramFiles(x86)", _.get(process.env, "ProgramFiles"));
+    const vswhereCommand = path.resolve(programFilesPath, "Microsoft Visual Studio", "Installer", "vswhere.exe");
     let vswhereOutput = null;
 
     try {

--- a/lib/vsDetect.js
+++ b/lib/vsDetect.js
@@ -1,14 +1,14 @@
 "use strict";
-let processHelpers = require("./processHelpers");
-let _ = require("lodash");
-let path = require("path");
+const processHelpers = require("./processHelpers");
+const _ = require("lodash");
+const path = require("path");
 
-let vsDetect = {
+const vsDetect = {
     isInstalled: async function (version) {
-        let vsInstalled = await this._isVSInstalled(version);
-        let vsvNextInstalled = await this._isVSvNextInstalled(version);
-        let buildToolsInstalled = await this._isBuildToolsInstalled(version);
-        let foundByVSWhere = await this._isFoundByVSWhere(version);
+        const vsInstalled = await this._isVSInstalled(version);
+        const vsvNextInstalled = await this._isVSvNextInstalled(version);
+        const buildToolsInstalled = await this._isBuildToolsInstalled(version);
+        const foundByVSWhere = await this._isFoundByVSWhere(version);
 
         return vsInstalled || vsvNextInstalled || buildToolsInstalled || foundByVSWhere;
     },
@@ -30,7 +30,7 @@ let vsDetect = {
     },
 
     _isBuildToolsInstalled: async function (version) {
-        let mainVer = version.split(".")[0];
+        const mainVer = version.split(".")[0];
         let key;
         let testPhrase;
         if (Number(mainVer) >= 15) {
@@ -41,9 +41,9 @@ let vsDetect = {
             key = "HKLM\\SOFTWARE\\Classes\\Installer\\Dependencies\\Microsoft.VS.VisualCppBuildTools_x86_enu,v" + mainVer;
             testPhrase = "Visual C++";
         }
-        let command = ["reg", "query", "\"" + key + "\""];
+        const command = ["reg", "query", "\"" + key + "\""];
         try {
-            let stdout = await processHelpers.execFile(command);
+            const stdout = await processHelpers.execFile(command);
             return stdout && stdout.indexOf(testPhrase) > 0;
         }
         catch (e) {
@@ -55,11 +55,11 @@ let vsDetect = {
     _isVSInstalled: async function (version) {
         // On x64 this will look for x64 keys only, but if VS and compilers installed properly,
         // it will write it's keys to 64 bit registry as well.
-        let command = ["reg", "query", "\"HKLM\\Software\\Microsoft\\VisualStudio\\" + version + "\""];
+        const command = ["reg", "query", "\"HKLM\\Software\\Microsoft\\VisualStudio\\" + version + "\""];
         try {
-            let stdout = await processHelpers.execFile(command);
+            const stdout = await processHelpers.execFile(command);
             if (stdout) {
-                let lines = stdout.split("\r\n").filter(function (line) {
+                const lines = stdout.split("\r\n").filter(function (line) {
                     return line.length > 10;
                 });
                 if (lines.length >= 4) {
@@ -74,12 +74,12 @@ let vsDetect = {
     },
 
     _isVSvNextInstalled: async function (version) {
-        let mainVer = version.split(".")[0];
-        let command = ["reg", "query", "\"HKLM\\SOFTWARE\\Classes\\Installer\\Dependencies\\Microsoft.VisualStudio.MinShell.Msi,v" + mainVer + "\""];
+        const mainVer = version.split(".")[0];
+        const command = ["reg", "query", "\"HKLM\\SOFTWARE\\Classes\\Installer\\Dependencies\\Microsoft.VisualStudio.MinShell.Msi,v" + mainVer + "\""];
         try {
-            let stdout = await processHelpers.execFile(command);
+            const stdout = await processHelpers.execFile(command);
             if (stdout) {
-                let lines = stdout.split("\r\n").filter(function (line) {
+                const lines = stdout.split("\r\n").filter(function (line) {
                     return line.length > 10;
                 });
                 if (lines.length >= 3) {

--- a/tests/es6/buildSystem.js
+++ b/tests/es6/buildSystem.js
@@ -1,17 +1,17 @@
 "use strict";
 /* global describe,it,before */
 
-let assert = require("assert");
-let lib = require("../../");
-let CMake = lib.CMake;
-let BuildSystem = lib.BuildSystem;
-let _ = require("lodash");
-let path = require("path");
-let Bluebird = require("bluebird");
-let async = Bluebird.coroutine;
-let log = require("npmlog");
-let testRunner = require("./testRunner");
-let testCases = require("./testCases");
+const assert = require("assert");
+const lib = require("../../");
+const CMake = lib.CMake;
+const BuildSystem = lib.BuildSystem;
+const _ = require("lodash");
+const path = require("path");
+const Bluebird = require("bluebird");
+const async = Bluebird.coroutine;
+const log = require("npmlog");
+const testRunner = require("./testRunner");
+const testCases = require("./testCases");
 
 describe("BuildSystem", function () {
     this.timeout(300000);
@@ -34,7 +34,7 @@ describe("BuildSystem", function () {
 
     it("should provide list of generators", function (done) {
         async(function*() {
-            let gens = yield CMake.getGenerators();
+            const gens = yield CMake.getGenerators();
             assert(_.isArray(gens));
             assert(gens.length > 0);
             assert.equal(gens.filter(function (g) { return g.length; }).length, gens.length);

--- a/tests/es6/dist.js
+++ b/tests/es6/dist.js
@@ -1,19 +1,19 @@
 "use strict";
 /* global describe,it */
 
-let Bluebird = require("bluebird");
-let fs = require("fs-extra");
-let Dist = require("../../").Dist;
-let assert = require("assert");
-let async = Bluebird.coroutine;
+const Bluebird = require("bluebird");
+const fs = require("fs-extra");
+const Dist = require("../../").Dist;
+const assert = require("assert");
+const async = Bluebird.coroutine;
 
-let testDownload = process.env.TEST_DOWNLOAD === "1";
+const testDownload = process.env.TEST_DOWNLOAD === "1";
 
 describe("dist", function () {
     it("should download dist files if needed", function (done) {
         this.timeout(60000);
         async(function*() {
-            let dist = new Dist();
+            const dist = new Dist();
             if (testDownload) {
                 yield fs.remove(dist.internalPath);
                 assert(dist.downloaded === false);

--- a/tests/es6/locateNAN.js
+++ b/tests/es6/locateNAN.js
@@ -1,11 +1,11 @@
 "use strict";
 /* global describe,it */
 
-let Bluebird = require("bluebird");
-let async = Bluebird.coroutine;
-let locateNAN = require("../../").locateNAN;
-let path = require("path");
-let assert = require("assert");
+const Bluebird = require("bluebird");
+const async = Bluebird.coroutine;
+const locateNAN = require("../../").locateNAN;
+const path = require("path");
+const assert = require("assert");
 
 /*
 
@@ -23,25 +23,25 @@ describe("locateNAN", function () {
     const NAN_DIR = path.join(PROJECT_DIR, "node_modules", "nan");
 
     it("should locate NAN from dependency", function () {
-        let dir = path.join(PROJECT_DIR, "node_modules", "dep-1");
+        const dir = path.join(PROJECT_DIR, "node_modules", "dep-1");
         return async(function*() {
-            let nan = yield locateNAN(dir);
+            const nan = yield locateNAN(dir);
             assert.equal(nan, NAN_DIR);
         })();
     });
 
     it("should locate NAN from nested dependency", function () {
-        let dir = path.join(PROJECT_DIR, "node_modules", "dep-1", "node_modules", "dep-3");
+        const dir = path.join(PROJECT_DIR, "node_modules", "dep-1", "node_modules", "dep-3");
         return async(function*() {
-            let nan = yield locateNAN(dir);
+            const nan = yield locateNAN(dir);
             assert.equal(nan, NAN_DIR);
         })();
     });
 
     it("should locate NAN from scoped dependency", function () {
-        let dir = path.join(PROJECT_DIR, "node_modules", "@scope", "dep-2");
+        const dir = path.join(PROJECT_DIR, "node_modules", "@scope", "dep-2");
         return async(function*() {
-            let nan = yield locateNAN(dir);
+            const nan = yield locateNAN(dir);
             assert.equal(nan, NAN_DIR);
         })();
     });

--- a/tests/es6/testCases.js
+++ b/tests/es6/testCases.js
@@ -1,26 +1,26 @@
 "use strict";
-let assert = require("assert");
-let lib = require("../../");
-let BuildSystem = lib.BuildSystem;
-let _ = require("lodash");
-let path = require("path");
-let Bluebird = require("bluebird");
-let async = Bluebird.coroutine;
-let fs = require("fs-extra");
+const assert = require("assert");
+const lib = require("../../");
+const BuildSystem = lib.BuildSystem;
+const _ = require("lodash");
+const path = require("path");
+const Bluebird = require("bluebird");
+const async = Bluebird.coroutine;
+const fs = require("fs-extra");
 
-let testCases = {
+const testCases = {
     buildPrototypeWithDirectoryOption: async(function*(options) {
         options = _.extend({
             directory: path.resolve(path.join(__dirname, "./prototype"))
         }, options);
-        let buildSystem = new BuildSystem(options);
+        const buildSystem = new BuildSystem(options);
         yield buildSystem.rebuild();
         assert.ok((yield fs.stat(path.join(__dirname, "prototype/build/Release/addon.node"))).isFile());
     }),
     buildPrototype2WithCWD: async(function*(options) {
-        let cwd = process.cwd();
+        const cwd = process.cwd();
         process.chdir(path.resolve(path.join(__dirname, "./prototype2")));
-        let buildSystem = new BuildSystem(options);
+        const buildSystem = new BuildSystem(options);
         try {
             yield buildSystem.rebuild();
             assert.ok((yield fs.stat(path.join(__dirname, "prototype2/build/Release/addon2.node"))).isFile());
@@ -34,9 +34,9 @@ let testCases = {
             directory: path.resolve(path.join(__dirname, "./prototype")),
             std: "c++98"
         }, options);
-        let buildSystem = new BuildSystem(options);
+        const buildSystem = new BuildSystem(options);
         if (!/visual studio/i.test(buildSystem.toolset.generator)) {
-            let command = yield buildSystem.getConfigureCommand();
+            const command = yield buildSystem.getConfigureCommand();
             assert.equal(command.indexOf("-std=c++11"), -1, "c++11 still forced");
         }
     }),
@@ -47,9 +47,9 @@ let testCases = {
               foo: "bar"
             }
         }, options);
-        let buildSystem = new BuildSystem(options);
+        const buildSystem = new BuildSystem(options);
 
-        let command = yield buildSystem.getConfigureCommand();
+        const command = yield buildSystem.getConfigureCommand();
         assert.notEqual(command.indexOf("-Dfoo=bar"), -1, "custom options added");
     })
 };

--- a/tests/es6/testRunner.js
+++ b/tests/es6/testRunner.js
@@ -1,12 +1,12 @@
 "use strict";
 /* global it */
-let lib = require("../../");
-let environment = lib.environment;
-let Bluebird = require("bluebird");
-let async = Bluebird.coroutine;
-let _ = require("lodash");
-let log = require("npmlog");
-let util = require("util");
+const lib = require("../../");
+const environment = lib.environment;
+const Bluebird = require("bluebird");
+const async = Bluebird.coroutine;
+const _ = require("lodash");
+const log = require("npmlog");
+const util = require("util");
 
 function* generateRuntimeOptions() {
     function* generateForNode(arch) {
@@ -71,7 +71,7 @@ function* generateRuntimeOptions() {
 }
 
 function* generateOptions() {
-    for (let runtimeOptions of generateRuntimeOptions()) {
+    for (const runtimeOptions of generateRuntimeOptions()) {
         if (environment.isWin) {
             // V C++:
             yield runtimeOptions;
@@ -95,10 +95,10 @@ function* generateOptions() {
     }
 }
 
-let testRunner = {
+const testRunner = {
     runCase: function (testCase, options) {
-        for (let testOptions of generateOptions()) {
-            let currentOptions = _.extend({}, testOptions, options || {});
+        for (const testOptions of generateOptions()) {
+            const currentOptions = _.extend({}, testOptions, options || {});
             it("should build with: " + util.inspect(currentOptions), function (done) {
                 async(function*() {
                     log.info("TEST", "Running case for options of: " + util.inspect(currentOptions));


### PR DESCRIPTION
This PR converts the usage of var/let to let/const using Eslint.

Eslint parses the AST and performs scope analysis and reference counting to verify that these changes are safe.

The example of conversion for lib folder:
```
eslint ./lib --rule 'no-var: 2' --fix
eslint ./lib --rule 'prefer-const: 2' --fix
```
