### PR TITLE
add workaround for windows case sensitive issue

### DIFF
--- a/lib/processHelpers.js
+++ b/lib/processHelpers.js
@@ -9,7 +9,12 @@ let processHelpers = {
     run: function (command, options) {
         options = _.defaults(options, {silent: false});
         return new Promise(function (resolve, reject) {
-            if (process.env.Path && process.env.PATH) delete process.env.Path;
+            if (process.platform === "win32" && process.env.Path !== undefined && process.env.PATH !== undefined) {
+                const path1 = process.env.Path.split(";");
+                const path2 = process.env.PATH.split(";");
+                delete process.env.PATH;
+                process.env.Path = [...new Set([...path1, ...path2])].join(";");
+            }
             let child = spawn(command[0], command.slice(1), {stdio: options.silent ? "ignore" : "inherit"});
             let ended = false;
             child.on("error", function (e) {

--- a/lib/processHelpers.js
+++ b/lib/processHelpers.js
@@ -10,10 +10,9 @@ let processHelpers = {
         options = _.defaults(options, {silent: false});
         return new Promise(function (resolve, reject) {
             if (process.platform === "win32" && process.env.Path !== undefined && process.env.PATH !== undefined) {
-                const path1 = process.env.Path.split(";");
-                const path2 = process.env.PATH.split(";");
+                const PATH = process.env.Path;
                 delete process.env.PATH;
-                process.env.Path = [...new Set([...path1, ...path2])].join(";");
+                process.env.Path = PATH;
             }
             let child = spawn(command[0], command.slice(1), {stdio: options.silent ? "ignore" : "inherit"});
             let ended = false;


### PR DESCRIPTION
This fixes t[he issue](https://github.com/cmake-js/cmake-js/issues/232) with windows case insensitive environment variables. It's a hack/workaround. A feature to remove duplicates from the environment has been put in place for node v15.0.0 and [won't be backported](https://github.com/nodejs/node/pull/35210#issuecomment-853894713).