### PR TITLE
Remove escaped quotes from windows registry queries

### DIFF
--- a/lib/vsDetect.js
+++ b/lib/vsDetect.js
@@ -41,7 +41,7 @@ let vsDetect = {
             key = "HKLM\\SOFTWARE\\Classes\\Installer\\Dependencies\\Microsoft.VS.VisualCppBuildTools_x86_enu,v" + mainVer;
             testPhrase = "Visual C++";
         }
-        let command = ["reg", "query", "\"" + key + "\""];
+        let command = ["reg", "query", key];
         try {
             let stdout = await processHelpers.execFile(command);
             return stdout && stdout.indexOf(testPhrase) > 0;
@@ -55,7 +55,7 @@ let vsDetect = {
     _isVSInstalled: async function (version) {
         // On x64 this will look for x64 keys only, but if VS and compilers installed properly,
         // it will write it's keys to 64 bit registry as well.
-        let command = ["reg", "query", "\"HKLM\\Software\\Microsoft\\VisualStudio\\" + version + "\""];
+        let command = ["reg", "query", "HKLM\\Software\\Microsoft\\VisualStudio\\" + version];
         try {
             let stdout = await processHelpers.execFile(command);
             if (stdout) {
@@ -75,7 +75,7 @@ let vsDetect = {
 
     _isVSvNextInstalled: async function (version) {
         let mainVer = version.split(".")[0];
-        let command = ["reg", "query", "\"HKLM\\SOFTWARE\\Classes\\Installer\\Dependencies\\Microsoft.VisualStudio.MinShell.Msi,v" + mainVer + "\""];
+        let command = ["reg", "query", "HKLM\\SOFTWARE\\Classes\\Installer\\Dependencies\\Microsoft.VisualStudio.MinShell.Msi,v" + mainVer];
         try {
             let stdout = await processHelpers.execFile(command);
             if (stdout) {


### PR DESCRIPTION
https://github.com/cmake-js/cmake-js/issues/249

Scanning through the docs for child_process -- https://nodejs.org/api/child_process.html#child_process_child_process_execfile_file_args_options_callback -- I can see that execFile includes a parameter controlling argument escaping, windowsVerbatimArguments, which default to false (and cmake-js does not override).  This lends some additional weight to the proposed fix to remove the manually-added quotes, as execFile should take care of it for us.