### PR TITLE
Add config flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Options:
   -d, --directory        specify CMake project's directory (where CMakeLists.txt
                          located)                                       [string]
   -D, --debug            build debug configuration                     [boolean]
+  -C, --config           specify build configuration (Debug, RelWithDebInfo,
+                         Release), will ignore '--debug' if specified   [string]
   -c, --cmake-path       path of CMake executable                       [string]
   -m, --prefer-make      use Unix Makefiles even if Ninja is available (Posix)
                                                                        [boolean]

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Options:
   -d, --directory        specify CMake project's directory (where CMakeLists.txt
                          located)                                       [string]
   -D, --debug            build debug configuration                     [boolean]
-  -C, --config           specify build configuration (Debug, RelWithDebInfo,
+  -B, --config           specify build configuration (Debug, RelWithDebInfo,
                          Release), will ignore '--debug' if specified   [string]
   -c, --cmake-path       path of CMake executable                       [string]
   -m, --prefer-make      use Unix Makefiles even if Ninja is available (Posix)

--- a/bin/cmake-js
+++ b/bin/cmake-js
@@ -66,6 +66,12 @@ var yargs = require("yargs")
             describe: "build debug configuration",
             type: "boolean"
         },
+        C: {
+            alias: "config",
+            demand: false,
+            describe: "specify build configuration (Debug, RelWithDebInfo, Release), will ignore '--debug' if specified",
+            type: "string"
+        },
         c: {
             alias: "cmake-path",
             demand: false,

--- a/bin/cmake-js
+++ b/bin/cmake-js
@@ -66,7 +66,7 @@ var yargs = require("yargs")
             describe: "build debug configuration",
             type: "boolean"
         },
-        C: {
+        B: {
             alias: "config",
             demand: false,
             describe: "specify build configuration (Debug, RelWithDebInfo, Release), will ignore '--debug' if specified",
@@ -218,7 +218,8 @@ var options = {
     arch: argv.a,
     cMakeOptions: customOptions,
     silent: argv.i,
-    out: argv.O
+    out: argv.O,
+    config: argv.B
 };
 
 log.verbose("CON", "options:");

--- a/lib/cMake.js
+++ b/lib/cMake.js
@@ -20,7 +20,7 @@ function CMake(options) {
     this.dist = new Dist(this.options);
     this.projectRoot = path.resolve(this.options.directory || process.cwd());
     this.workDir = path.resolve(this.options.out || path.join(this.projectRoot, "build"));
-    this.config = this.options.config || this.options.debug ? "Debug" : "Release";
+    this.config = this.options.config || (this.options.debug ? "Debug" : "Release");
     this.buildDir = path.join(this.workDir, this.config);
     this._isAvailable = null;
     this.targetOptions = new TargetOptions(this.options);

--- a/lib/cMake.js
+++ b/lib/cMake.js
@@ -20,7 +20,7 @@ function CMake(options) {
     this.dist = new Dist(this.options);
     this.projectRoot = path.resolve(this.options.directory || process.cwd());
     this.workDir = path.resolve(this.options.out || path.join(this.projectRoot, "build"));
-    this.config = this.options.debug ? "Debug" : "Release";
+    this.config = this.options.config || this.options.debug ? "Debug" : "Release";
     this.buildDir = path.join(this.workDir, this.config);
     this._isAvailable = null;
     this.targetOptions = new TargetOptions(this.options);


### PR DESCRIPTION
Based on https://github.com/cmake-js/cmake-js/pull/216, which wasn't quite feature complete. I fixed the logic and added the build type configuration parameter to the options object so that a user can now specify custom CMAKE_BUILD_TYPE.