### PR TITLE
Auto-detect platform for Visual Studio 2019 and above

### DIFF
--- a/lib/toolset.js
+++ b/lib/toolset.js
@@ -172,10 +172,17 @@ Toolset.prototype.initializeWin = async function (install) {
             this.linkerFlags.push("/SAFESEH:NO");
         }
 
+        let ver = 0;
+        let found = /^visual studio (\d+)/i.exec(topVS);
+        if (found) {
+            ver = parseInt(found[1]);
+        }
+        const isAboveVS16 = ver >= 16;
+
         // The CMake Visual Studio Generator does not support the Win64 or ARM suffix on
         // the generator name. Instead the generator platform must be set explicitly via
         // the platform parameter
-        if (!this.platform && this.generator.startsWith("Visual Studio 16")) {
+        if (!this.platform && isAboveVS16) {
             switch(this.targetOptions.arch) {
                 case "ia32":
                     this.platform = "Win32";


### PR DESCRIPTION
cmake-js will only match "Visual Studio 16" for detecting platform, this PR change to getting the version of visual studio, and set platform according to the version.
Adding support for visual studio 2022 is the main purpose.
Open this new PR to avoid line ending issue.