### PR TITLE
Update baseurl for electron mirror

### DIFF
--- a/lib/runtimePaths.js
+++ b/lib/runtimePaths.js
@@ -4,7 +4,7 @@ const semver = require("semver");
 const isPlainObject = require("lodash.isplainobject");
 
 const NODE_MIRROR = process.env.NVM_NODEJS_ORG_MIRROR || "https://nodejs.org/dist";
-const ELECTRON_MIRROR = process.env.ELECTRON_MIRROR || "https://atom.io/download/atom-shell";
+const ELECTRON_MIRROR = process.env.ELECTRON_MIRROR || "https://artifacts.electronjs.org/headers/dist";
 
 const runtimePaths = {
     node: function (targetOptions) {


### PR DESCRIPTION
On 05/06/2022, Electron changed the upload location of build artifacts. The former URL is not immediately obsolete, but will not reflect future updates. For example, Electron v19 build artifacts only exist in the new location now.
https://github.com/electron/electronjs.org/blob/2a2b89eca826710ed3d7b17d9b3e0a7534abfdc4/data/blog/s3-bucket-change.md
For example, currently, the following error occurred when trying to use v19.
```
info TOOL Using Unix Makefiles generator.
info DIST Downloading distribution files to: /Users/user/.cmake-js/electron-arm64/v19.0.3
http DIST       - https://atom.io/download/atom-shell/v19.0.3/node-v19.0.3.tar.gz
ERR! OMG Request failed with status code 403
ERR! OMG Request failed with status code 403
```
Missing version list generator: https://replit.com/@ci7lus/electron-listup