### PR TITLE
Search for package.json starting from cwd rather than --directory

### DIFF
--- a/lib/buildSystem.js
+++ b/lib/buildSystem.js
@@ -24,8 +24,8 @@ function BuildSystem(options) {
     this.options.directory = path.resolve(this.options.directory || process.cwd());
     this.options.out = path.resolve(this.options.out || path.join(this.options.directory, "build"));
     this.log = new CMLog(this.options);
-    this.options.isNodeApi = isNodeApi(this.log, this.options.directory)
-    const appConfig = appCMakeJSConfig(this.options.directory, this.log);
+    this.options.isNodeApi = isNodeApi(this.log, path.resolve(process.cwd()))
+    const appConfig = appCMakeJSConfig(path.resolve(process.cwd()), this.log);
     const npmOptions = npmConfig(this.log);
 
     if (isPlainObject(npmOptions) && Object.keys(npmOptions).length) {

--- a/lib/cMake.js
+++ b/lib/cMake.js
@@ -153,7 +153,7 @@ CMake.prototype.getConfigureCommand = async function (nodeLibDefPath) {
         }
 
         // NAN
-        const nanH = await locateNAN(this.projectRoot);
+        const nanH = await locateNAN(path.resolve(process.cwd()));
         if (nanH) {
             incPaths.push(nanH);
         }
@@ -163,7 +163,7 @@ CMake.prototype.getConfigureCommand = async function (nodeLibDefPath) {
         incPaths.push(apiHeaders.include_dir)
 
         // Node-api
-        const napiH = await locateNodeApi(this.projectRoot)
+        const napiH = await locateNodeApi(path.resolve(process.cwd()));
         if (napiH) {
             incPaths.push(napiH)
         }


### PR DESCRIPTION
`--directory` is documented to only specify where `CMakeLists.txt` should be found, thus it should not be used to look for `package.json` as such a lookup will fail if `--directory` is not a subdirectory of the current working directory (for example if `CMakeLists.txt` is in a parent or sibling directory).

cmake-js should instead use `process.cwd()` when searching for `package.json` even if `--directory` is provided.