### PR TITLE
Do not print all command line arguments to stdout on each cmake-js run

### DIFF
--- a/bin/cmake-js
+++ b/bin/cmake-js
@@ -23,8 +23,6 @@ for (const [key, value] of Object.entries(npmConfigData)) {
     }
 }
 
-console.log(process.argv);
-
 const yargs = require("yargs")
     .usage("CMake.js " + version + "\n\nUsage: $0 [<command>] [options]")
     .version(version)


### PR DESCRIPTION
I want to get CMake configuration command from cmake-js, I'm trying to do that using `npx cmake-js print-configure`, but also getting array of command line arguments - not a big deal, but it makes using of this output in script not very easy(no problem with `info TOOL Using Ninja generator, because ninja is available.` since it goes to stderr). Have no idea why it is needed, probably some artefact after debug or something like this, so I propose to remove it.