### PR TITLE
Add `cmake-js options` command

### DIFF
--- a/bin/cmake-js
+++ b/bin/cmake-js
@@ -288,6 +288,12 @@ function rebuild() {
 function compile() {
     exitOnError(buildSystem.compile());
 }
+function cmakeOptions() {
+    exitOnError(buildSystem.cmakeOptions()
+        .then(function (result) {
+            console.info(result);
+        }));
+}
 
 let done = ifCommand("install", install);
 done = done || ifCommand("configure", configure);
@@ -299,6 +305,7 @@ done = done || ifCommand("print-clean", printClean);
 done = done || ifCommand("reconfigure", reconfigure);
 done = done || ifCommand("rebuild", rebuild);
 done = done || ifCommand("compile", compile);
+done = done || ifCommand("options", cmakeOptions);
 
 if (!done) {
     if (command) {

--- a/lib/buildSystem.js
+++ b/lib/buildSystem.js
@@ -126,5 +126,8 @@ BuildSystem.prototype.rebuild = function () {
 BuildSystem.prototype.compile = function () {
     return this._invokeCMake("compile");
 };
+BuildSystem.prototype.cmakeOptions = function () {
+    return this._invokeCMake("cmakeOptions");
+};
 
 module.exports = BuildSystem;

--- a/lib/cMake.js
+++ b/lib/cMake.js
@@ -117,10 +117,15 @@ CMake.prototype.verifyIfAvailable = function () {
     }
 };
 
-CMake.prototype.getConfigureCommand = async function (nodeLibDefPath) {
-    // Create command:
-    let command = [this.path, this.projectRoot, "--no-warn-unused-cli"];
+CMake.prototype.cmakeOptions = async function () {
+    const nodeLibDefPath = environment.isWin && this.options.isNodeApi ? path.join(this.options.out, 'node-lib.def') : undefined;
+    const D = await this.getCMakeOptions(nodeLibDefPath);  
+    return D.map(function (p) {
+        return "-D" + Object.keys(p)[0] + "=" + Object.values(p)[0];
+    }).join(' ');
+};
 
+CMake.prototype.getCMakeOptions = async function (nodeLibDefPath) {
     const D = [];
 
     // CMake.js watermark
@@ -199,35 +204,6 @@ CMake.prototype.getConfigureCommand = async function (nodeLibDefPath) {
     for (const [key, value] of Object.entries(this.cMakeOptions)) {
         D.push({ [key]: value });
     }
-
-    // Toolset:
-    await this.toolset.initialize(false);
-
-    if (environment.isWin) {
-        // Win
-        const libs = []
-        if (nodeLibDefPath) {
-            const nodeLibPath = path.join(this.workDir, 'node.lib')
-            D.push({ CMAKE_JS_NODELIB_DEF: nodeLibDefPath })
-            D.push({ CMAKE_JS_NODELIB_TARGET: nodeLibPath })
-            libs.push(nodeLibPath)
-        } else {
-            libs.push(...this.dist.winLibs)
-        }
-        if (libs.length) {
-            D.push({"CMAKE_JS_LIB": libs.join(";")});
-        }
-    }
-
-    if (this.toolset.generator) {
-        command.push("-G", this.toolset.generator);
-    }
-    if (this.toolset.platform) {
-        command.push("-A", this.toolset.platform);
-    }
-    if (this.toolset.toolset) {
-        command.push("-T", this.toolset.toolset);
-    }
     if (this.toolset.cppCompilerPath) {
         D.push({"CMAKE_CXX_COMPILER": this.toolset.cppCompilerPath});
     }
@@ -252,6 +228,43 @@ CMake.prototype.getConfigureCommand = async function (nodeLibDefPath) {
                 D.push({ [sk]: value });
             }
         }
+    }
+    return D;
+};
+
+CMake.prototype.getConfigureCommand = async function (nodeLibDefPath) {
+    // Create command:
+    let command = [this.path, this.projectRoot, "--no-warn-unused-cli"];
+
+    const D = await this.getCMakeOptions(nodeLibDefPath);
+    
+    // Toolset:
+    await this.toolset.initialize(false);
+
+    if (environment.isWin) {
+        // Win
+        const libs = [];
+        if (nodeLibDefPath) {
+            const nodeLibPath = path.join(this.workDir, 'node.lib')
+            D.push({ CMAKE_JS_NODELIB_DEF: nodeLibDefPath })
+            D.push({ CMAKE_JS_NODELIB_TARGET: nodeLibPath })
+            libs.push(nodeLibPath)
+        } else {
+            libs.push(...this.dist.winLibs)
+        }
+        if (libs.length) {
+            D.push({"CMAKE_JS_LIB": libs.join(";")});
+        }
+    }
+
+    if (this.toolset.generator) {
+        command.push("-G", this.toolset.generator);
+    }
+    if (this.toolset.platform) {
+        command.push("-A", this.toolset.platform);
+    }
+    if (this.toolset.toolset) {
+        command.push("-T", this.toolset.toolset);
     }
 
     command = command.concat(D.map(function (p) {
@@ -288,7 +301,7 @@ CMake.prototype._generateNodeLibDef = async function (targetFile) {
 CMake.prototype.configure = async function () {
     this.verifyIfAvailable();
 
-    const nodeLibDefPath = environment.isWin && this.options.isNodeApi ? path.join(this.options.out, 'node-lib.def') : undefined
+    const nodeLibDefPath = environment.isWin && this.options.isNodeApi ? path.join(this.options.out, 'node-lib.def') : undefined;
 
     this.log.info("CMD", "CONFIGURE");
     const listPath = path.join(this.projectRoot, "CMakeLists.txt");


### PR DESCRIPTION
# Idea
I want to try cmake-js in [project](https://github.com/Project-OSRM/osrm-backend) which is CMake-based, but it is not only NodeJs addon, but also usual C++ library, so in our CI we will have to use not only cmake-js commands, but also usual CMake commands, i.e. it leads to a lot of if-else in CI code(`if node_addon: cmake-js .. else: cmake ..`). The idea is to continue using CMake, but with a little help of cmake-js, i.e. something like this:
```
cmake -DMY_OWN_OPTION1=ON -DMY_ANOTHER_OPTION2=OFF $(cmake-js options) ..
ninja
```

So this PR is draft implementing this use case, but before polishing it would be great to hear maintainers opinion :) 

