### PR TITLE
fix: win_delay_load_hook.cc will fall back to the host process

### DIFF
--- a/lib/cpp/win_delay_load_hook.cc
+++ b/lib/cpp/win_delay_load_hook.cc
@@ -40,6 +40,9 @@ static FARPROC WINAPI load_exe_hook(unsigned int event, DelayLoadInfo* info) {
 
   if (_stricmp(info->szDll, "node.exe") != 0)
     return NULL;
+  
+  // Fall back to the current process
+  if(!node_dll) node_dll = GetModuleHandleA(NULL);
 
   return (FARPROC) node_dll;
 }


### PR DESCRIPTION
The current `win_delay_load_hook.cc` does not account for situations where the host process is statically linked to node.exe but has been renamed.

When e.g. using `pkg` to create a single executable, any `.node` modules linked to `node.exe` will fail unless the final binary is also called `node.exe`.

This makes the hook more similar to that of node-gyp. See https://github.com/nodejs/node-gyp/blob/main/src/win_delay_load_hook.cc#L31