### PR TITLE
feat: Forward extra arguments to CMake commands

### DIFF
--- a/bin/cmake-js
+++ b/bin/cmake-js
@@ -224,7 +224,8 @@ const options = {
     silent: argv.i,
     out: argv.O,
     config: argv.B,
-    parallel: argv.p
+    parallel: argv.p,
+    extraCMakeArgs: argv._.slice(1),
 };
 
 log.verbose("CON", "options:");

--- a/lib/cMake.js
+++ b/lib/cMake.js
@@ -25,6 +25,7 @@ function CMake(options) {
     this.targetOptions = new TargetOptions(this.options);
     this.toolset = new Toolset(this.options);
     this.cMakeOptions = this.options.cMakeOptions || {};
+    this.extraCMakeArgs = this.options.extraCMakeArgs || [];
     this.silent = !!options.silent;
 }
 
@@ -135,11 +136,11 @@ CMake.prototype.getConfigureCommand = async function () {
 	else {
 		D.push({"CMAKE_LIBRARY_OUTPUT_DIRECTORY": this.buildDir});
 	}
-    
+
     // In some configurations MD builds will crash upon attempting to free memory.
-    // This tries to encourage MT builds which are larger but less likely to have this crash. 
+    // This tries to encourage MT builds which are larger but less likely to have this crash.
     D.push({"CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded$<$<CONFIG:Debug>:Debug>"})
-    
+
     // Includes:
     const includesString = await this.getCmakeJsIncludeString();
     D.push({ "CMAKE_JS_INC": includesString });
@@ -220,11 +221,11 @@ CMake.prototype.getConfigureCommand = async function () {
             return "-D" + Object.keys(p)[0] + "=" + Object.values(p)[0];
         }));
 
-    return command;
+    return command.concat(this.extraCMakeArgs);
 };
 
 CMake.prototype.getCmakeJsLibString = function () {
-    
+
     const libs = []
     if (environment.isWin) {
         const nodeLibDefPath = this.getNodeLibDefPath()
@@ -364,7 +365,7 @@ CMake.prototype.getBuildCommand = function () {
     if (this.options.parallel) {
         command.push("--parallel", this.options.parallel);
     }
-    return Promise.resolve(command);
+    return Promise.resolve(command.concat(this.extraCMakeArgs));
 };
 
 CMake.prototype.build = async function () {
@@ -377,7 +378,7 @@ CMake.prototype.build = async function () {
 };
 
 CMake.prototype.getCleanCommand = function () {
-    return [this.path, "-E", "remove_directory", this.workDir];
+    return [this.path, "-E", "remove_directory", this.workDir].concat(this.extraCMakeArgs);
 };
 
 CMake.prototype.clean = function () {

--- a/lib/cMake.js
+++ b/lib/cMake.js
@@ -389,16 +389,19 @@ CMake.prototype.clean = function () {
 };
 
 CMake.prototype.reconfigure = async function () {
+    this.extraCMakeArgs = [];
     await this.clean();
     await this.configure();
 };
 
 CMake.prototype.rebuild = async function () {
+    this.extraCMakeArgs = [];
     await this.clean();
     await this.build();
 };
 
 CMake.prototype.compile = async function () {
+    this.extraCMakeArgs = [];
     try {
         await this.build();
     }

--- a/tests/es6/buildSystem.js
+++ b/tests/es6/buildSystem.js
@@ -3,7 +3,7 @@
 
 const assert = require("assert");
 const lib = require("../../");
-const locateNAN = require("../../lib/locateNAN")
+const locateNAN = require("../../lib/locateNAN");
 const CMake = lib.CMake;
 const path = require("path");
 const log = require("npmlog");
@@ -39,7 +39,7 @@ describe("BuildSystem", function () {
     it("should rebuild prototype if cwd is the source directory", async function () {
         await testCases.buildPrototype2WithCWD();
     });
-    
+
     it("should build prototpye with nodeapi", async function () {
         await testCases.buildPrototypeNapi();
     });
@@ -51,5 +51,9 @@ describe("BuildSystem", function () {
 
     it("should configure with custom option", async function () {
         await testCases.configureWithCustomOptions();
+    });
+
+    it("should forward extra arguments to CMake", async function () {
+      await testCases.shouldForwardExtraCMakeArgs();
     });
 });

--- a/tests/es6/testCases.js
+++ b/tests/es6/testCases.js
@@ -63,7 +63,25 @@ const testCases = {
 
         const command = await buildSystem.getConfigureCommand();
         assert.notEqual(command.indexOf("-Dfoo=bar"), -1, "custom options added");
-    }
+    },
+    shouldForwardExtraCMakeArgs: async function(options) {
+        options = {
+            directory: path.resolve(path.join(__dirname, "./prototype")),
+            ...options
+        };
+
+        options.extraCMakeArgs = ["--debug-find-pkg=Boost", "--trace-source=FindBoost.cmake"];
+        const configure = await (new BuildSystem(options)).getConfigureCommand();
+        assert.deepEqual(configure.slice(-2), options.extraCMakeArgs, "extra CMake args appended");
+
+        options.extraCMakeArgs = ["--", "CMakeFiles/x.dir/y.cpp.o"];
+        const build = await (new BuildSystem(options)).getBuildCommand();
+        assert.deepEqual(build.slice(-2), options.extraCMakeArgs, "extra CMake args appended");
+
+        options.extraCMakeArgs = [".cache", "/tmp/jest_rs"];
+        const clean = await (new BuildSystem(options)).getCleanCommand();
+        assert.deepEqual(clean.slice(-2), options.extraCMakeArgs, "extra CMake args appended");
+      }
 };
 
 module.exports = testCases;


### PR DESCRIPTION
Partial duplicate of https://github.com/cmake-js/cmake-js/pull/235, except this PR:
* passes all `yargs`' unknown args to cmake (the ones after `--`)
* forwards args for all the basic commands (`clean`/`configure`/`build`)
  * does _not_ forward args for composite commands (`compile`/`rebuild`/`reconfigure`)

Examples why this is nice:

```shell
# Handy to help track down configuration issues
npx cmake-js configure -- --debug-find-pkg=Foo --trace-source=FindFoo.cmake
# yields:
#   cmake {-D args...} --debug-find-pkg=Foo --trace-source=FindFoo.cmake

# For when you just need to rebuild a single target
# Note: needs the double "--" (one for yargs, the other for CMake)
npx cmake-js build -- -- CMakeFiles/my_lib.dir/my_src.cpp.o
#  yields:
#   cmake --build build --config Release -- CMakeFiles/my_lib.dir/my_src.cpp.o

# Remove additional dirs on clean
npx cmake-js clean -- .cache /tmp/jest_rs
# yields:
#   cmake -E remove_directory ./build .cache /tmp/jest_rs
```

And can be paired with `--` in `package.json` npm scripts to forward args mostly* without extra `--`:
```shell
# package.json
# {
#   "scripts": {
#     "cpp:clean": "cmake-js clean -O build/Release --",
#     "cpp:build": "cmake-js -g build -O build/Release --",
#     "cpp:configure": "cmake-js -g configure -O build/Release --",
#   }
# }

yarn cpp:clean .cache /tmp/jest_rs
npm run cpp:clean -- .cache /tmp/jest_rs

yarn cpp:configure --debug-find-pkg=Foo --trace-source=FindFoo.cmake
npm run cpp:configure -- --debug-find-pkg=Foo --trace-source=FindFoo.cmake

# * yarn classic needs double-double-hyphen because it eats the first one like npm
yarn cpp:build -- -- CMakeFiles/my_lib.dir/my_src.cpp.o
npm run cpp:build -- -- CMakeFiles/my_lib.dir/my_src.cpp.o
```