### PR TITLE
fix: `-DCMAKE_JS_VERSION=undefined`

### DIFF
--- a/lib/cMake.js
+++ b/lib/cMake.js
@@ -125,7 +125,7 @@ CMake.prototype.getConfigureCommand = async function () {
     const D = [];
 
     // CMake.js watermark
-    D.push({"CMAKE_JS_VERSION": environment.moduleVersion});
+    D.push({"CMAKE_JS_VERSION": environment.cmakeJsVersion});
 
     // Build configuration:
     D.push({"CMAKE_BUILD_TYPE": this.config});


### PR DESCRIPTION
Fix issue that causes this:
```
info CMD CONFIGURE
info RUN [
info RUN   'cmake',
info RUN   ...
info RUN   '-DCMAKE_JS_VERSION=undefined',
info RUN   ...
info RUN ]
```

Fixes https://github.com/cmake-js/cmake-js/issues/295