### PR TITLE
fix: Only add build type to `CMAKE_LIBRARY_OUTPUT_DIRECTORY` if needed

### DIFF
--- a/lib/cMake.js
+++ b/lib/cMake.js
@@ -130,16 +130,19 @@ CMake.prototype.getConfigureCommand = async function () {
     // Build configuration:
     D.push({"CMAKE_BUILD_TYPE": this.config});
     if (environment.isWin) {
-		D.push({"CMAKE_RUNTIME_OUTPUT_DIRECTORY": this.workDir});
-	}
-	else {
-		D.push({"CMAKE_LIBRARY_OUTPUT_DIRECTORY": this.buildDir});
-	}
-    
+        D.push({"CMAKE_RUNTIME_OUTPUT_DIRECTORY": this.workDir});
+    }
+    else if (this.workDir.endsWith(this.config)) {
+        D.push({"CMAKE_LIBRARY_OUTPUT_DIRECTORY": this.workDir});
+    }
+    else {
+        D.push({"CMAKE_LIBRARY_OUTPUT_DIRECTORY": this.buildDir});
+    }
+
     // In some configurations MD builds will crash upon attempting to free memory.
-    // This tries to encourage MT builds which are larger but less likely to have this crash. 
+    // This tries to encourage MT builds which are larger but less likely to have this crash.
     D.push({"CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded$<$<CONFIG:Debug>:Debug>"})
-    
+
     // Includes:
     const includesString = await this.getCmakeJsIncludeString();
     D.push({ "CMAKE_JS_INC": includesString });
@@ -224,7 +227,7 @@ CMake.prototype.getConfigureCommand = async function () {
 };
 
 CMake.prototype.getCmakeJsLibString = function () {
-    
+
     const libs = []
     if (environment.isWin) {
         const nodeLibDefPath = this.getNodeLibDefPath()


### PR DESCRIPTION
This PR only appends `CMAKE_BUILD_TYPE` to `CMAKE_LIBRARY_OUTPUT_DIRECTORY` if the build dir path doesn't already end with the build type.

Maintaining parallel build trees for release/debug can reduce rebuild times when switching between configs*.

If a user wishes to configure this way today, `cmake-js` defines a nonsense path for `LIBRARY_OUTPUT_DIRECTORY`:

```shell
npx cmake-js -D -O build/Debug
# -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=build/Debug/Debug

npx cmake-js -O build/Release
# -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=build/Release/Release
```

I assume this is to align with `node-gyp` and `require('bindings')('foo.node')`, which this PR would still support.

If the user configured into `build/${cmake_build_type}`, the `LIBRARY_OUTPUT_DIRECTORY` should be `${cmake_binary_dir}`, not `${cmake_binary_dir}/{cmake_build_type}`.

\* An alternative could be to customize the location of the object files based on build type... but this [isn't supported](https://cmake.org/pipermail/cmake/2010-July/038462.html) by CMake :slightly_frowning_face:.