### PR TITLE
Adjust 7.X to support NodeJS 10+ as minimum version

### DIFF
--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -92,3 +92,90 @@ jobs:
 
             npm install
             npm test
+
+  test-node10:
+    name: Run tests for ${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.libc }} on NodeJS 10
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # windows
+          - os: windows-2019
+            arch: x64
+          - os: windows-2022
+            arch: x64
+          - os: windows-2019
+            arch: x86
+          # macos
+          - os: macos-12
+            arch: x64
+          - os: macos-10.15
+            arch: x64
+          # linux
+          - os: ubuntu-22.04
+            arch: x64
+          - os: ubuntu-18.04
+            arch: x64
+          # linux-libc
+          - os: ubuntu-latest
+            arch: arm64
+            docker-arch: linux/arm64
+            docker-image: node:14-bullseye
+          - os: ubuntu-latest
+            arch: arm
+            docker-arch: linux/arm/v7
+            docker-image: node:14-bullseye
+          # linux-musl
+          - os: ubuntu-latest
+            arch: x64
+            docker-arch: linux/amd64
+            docker-image: node:14-alpine
+            libc: musl
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js 10.13+
+        if: ${{ !matrix.docker-arch }}
+        uses: actions/setup-node@v3
+        with:
+          architecture: ${{ matrix.arch }}
+          node-version: 10.13.x
+
+      - name: run tests
+        if: ${{ !matrix.docker-arch }}
+        shell: bash
+        run: |
+          npm install
+          npm test
+        env:
+          CI: true
+          npm_config_build_from_source: true
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        if: matrix.docker-arch
+      - name: run tests (in docker)
+        uses: addnab/docker-run-action@v3
+        if: matrix.docker-arch
+        with:
+          image: ${{ matrix.docker-image }}
+          # shell: bash
+          options: --platform=${{ matrix.docker-arch }} -v ${{ github.workspace }}:/work -e CI=1
+          run: |
+            if command -v apt-get &> /dev/null
+            then
+              apt-get update
+              apt-get install -y cmake
+            elif command -v apk &> /dev/null
+            then
+              apk update
+              apk add cmake make g++ gcc
+            fi
+
+            cd /work
+
+            npm install
+            npm test

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ## About
 CMake.js is a Node.js native addon build tool which works (almost) *exactly* like [node-gyp](https://github.com/TooTallNate/node-gyp), but instead of [gyp](http://en.wikipedia.org/wiki/GYP_%28software%29), it is based on [CMake](http://cmake.org) build system. It's compatible with the following runtimes:
 
-- Node.js 14.15+ since CMake.js v7.0.0 (for older runtimes please use an earlier version of CMake.js). Newer versions can produce builds targetting older runtimes
+- Node.js 10+ since CMake.js v7.0.0 (for older runtimes please use an earlier version of CMake.js). Newer versions can produce builds targetting older runtimes
 - [NW.js](https://github.com/nwjs/nw.js): all CMake.js based native modules are compatible with NW.js out-of-the-box, there is no [nw-gyp like magic](https://github.com/nwjs/nw.js/wiki/Using-Node-modules#3rd-party-modules-with-cc-addons) required
 - [Electron](https://github.com/electron/electron): out-of-the-box build support, [no post build steps required](https://github.com/electron/electron/blob/main/docs/tutorial/using-native-node-modules.md)
 
@@ -279,7 +279,7 @@ Available settings:
 which was previously known as N-API, supplies a set of C
 APIs that allow to compilation and loading of native modules by
 different versions of Node.js that support Node-API which includes
-all versions of Node.js v10.x and later. 
+all versions of Node.js v10.x and later.
 
 To compile a native module that uses only the
 [plain `C` Node-API calls](https://nodejs.org/api/n-api.html#n_api_node_api),

--- a/lib/buildSystem.js
+++ b/lib/buildSystem.js
@@ -12,7 +12,11 @@ function isNodeApi(log, projectRoot) {
     try {
         const projectPkgJson = require(path.join(projectRoot, 'package.json'))
         // Make sure the property exists
-        return !!projectPkgJson?.binary?.napi_versions
+        if (projectPkgJson && projectPkgJson.binary) {
+            return !!projectPkgJson.binary.napi_versions;
+        }
+        log.silly("CFG", "'package.json' not found or does not have binary.");
+        return false
     } catch (e) {
         log.silly("CFG", "'package.json' not found.");
         return false

--- a/lib/locateNodeApi.js
+++ b/lib/locateNodeApi.js
@@ -8,9 +8,9 @@ const locateNodeApi = module.exports = async function (projectRoot) {
     }
 
     try {
-        const tmpRequire = require('module').createRequire(path.join(projectRoot, 'package.json'))
-        const inc = tmpRequire('node-addon-api')
-        return inc.include.replace(/"/g, '')
+        let requirePath = require("node-addon-api").include
+        requirePath = requirePath.replace(/"/g, '');
+        return requirePath;
     } catch (e) {
         // It most likely wasn't found
         return null;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build",
     "buildtools",
     "cmake",
-    "nw.js",  
+    "nw.js",
     "electron",
     "boost",
     "nan",
@@ -38,10 +38,10 @@
     "cmake-js": "./bin/cmake-js"
   },
   "engines": {
-    "node": ">= 14.15.0"
+    "node": ">= 10.0.0"
   },
   "dependencies": {
-    "axios": "^1.3.2",
+    "axios": "^0.27.2",
     "debug": "^4",
     "fs-extra": "^10.1.0",
     "lodash.isplainobject": "^4.0.6",
@@ -56,7 +56,7 @@
     "yargs": "^17.6.0"
   },
   "devDependencies": {
-    "mocha": "*",
+    "mocha": "^9.2.2",
     "nan": "^2.16.0",
     "node-addon-api": "^6.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -53,12 +53,12 @@
     "tar": "^6.1.11",
     "url-join": "^4.0.1",
     "which": "^2.0.2",
-    "yargs": "^17.6.0"
+    "yargs": "^16.2.0"
   },
   "devDependencies": {
     "mocha": "^9.2.2",
     "nan": "^2.16.0",
-    "node-addon-api": "^6.0.0"
+    "node-addon-api": "^3.2.1"
   },
   "scripts": {
     "test": "mocha tests",


### PR DESCRIPTION
This PR introduces changes needed to allow 7.X to work with NodeJS version 10+, dropping the minimum requirement from NodeJS 14+ to NodeJS 10+.

This PR will allow users using NodeJS 10 to update from 6.X to 7.X, closing #292. I work on the [AWS IoT SDK for Javascript V2](https://github.com/aws/aws-iot-device-sdk-js-v2) and unfortunately we cannot update from 6.X to 7.X easily because our minimum NodeJS version is 10.13+, and so we cannot fix the vulnerability reported in #292 by upgrading the version of CMakeJS we use.
(*It's only a built-time issue for us and we control the input going to it, therefore has no direct security impact in our case. We still get security reports on it though and therefore ideally would like to fix it if possible.*)

To add NodeJS 10+ support to 7.X, this PR makes the following changes:
* Adjusts the code to not rely on any NodeJS features beyond NodeJS 10.
  * The biggest change is removing the use of `require("module").createRequire` since it's a NodeJS 12 feature and replacing it with getting the include directory from `require("node-addon-api").include` directly.
* Adjusts packages to the latest versions that support NodeJS 10. Packages impacted are:
  * `axios` -> `^1.3.2` to `^0.27.2`
  * `yargs` -> `^17.6.0` to `^16.2.0`
  * `mocha` -> latest (`*`) to `^9.2.2`
  * `node-addon-api` -> `^6.0.0` to `^3.2.1`
* Adds NodeJS 10 tests to CI alongside the existing NodeJS 14 tests
* Adjusts README documentation to mention NodeJS 10 as the minimum supported version.

All changes were tested with the test suite in CMakeJS on both NodeJS 14 and NodeJS 10 and all tests are passing. I also tested building the [AWS IoT CRT for Javascript](https://github.com/awslabs/aws-crt-nodejs) and the [AWS IoT SDK for Javascript](https://github.com/aws/aws-iot-device-sdk-js-v2) on MacOS and confirmed both worked as expected with these changes.

_____________

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.