### PR TITLE
always remove `Path` if `PATH` is also defined

### DIFF
--- a/lib/processHelpers.js
+++ b/lib/processHelpers.js
@@ -8,8 +8,10 @@ const processHelpers = {
 
         return new Promise(function (resolve, reject) {
             const env = Object.assign({}, process.env);
-            if (env.Path && env.PATH && env.Path !== env.PATH) {
-                env.PATH = env.Path + ';' + env.PATH;
+            if (env.Path && env.PATH) {
+                if(env.Path !== env.PATH) {
+                    env.PATH = env.Path + ';' + env.PATH;
+                }
                 delete env.Path;
             }
             const child = spawn(command[0], command.slice(1), {


### PR DESCRIPTION
Bash on Windows defines both PATH and Path. This leads to a crash in MSBuild. Currently, `Path` is only removed from the environment, if it is the not the same as `PATH`. This commit changes this such, that `Path` is always removed, but if the two are not the same, it is appenden to `PATH`, too.

Closes #318 