### PR TITLE
Add win_delay_load_hook.c

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ You should add the following to your package.json, with the correct version numb
 #### Electron
 
 On Windows, the [`win_delay_load_hook`](https://www.electronjs.org/docs/tutorial/using-native-node-modules#a-note-about-win_delay_load_hook) is required to be embedded in the module or it will fail to load in the render process.
-cmake-js will add the hook if the CMakeLists.txt contains the library `${CMAKE_JS_SRC}`.
+cmake-js will add the hook if the CMakeLists.txt contains the library `${CMAKE_JS_SRC}`. (Or `${CMAKE_JS_SRC_C}` for C modules.)
 
 Without the hook, the module can only be called from the render process using the Electron [remote](https://github.com/electron/electron/blob/master/docs/api/remote.md) module.
 

--- a/lib/buildSystem.js
+++ b/lib/buildSystem.js
@@ -107,6 +107,10 @@ BuildSystem.prototype.getCmakeJsSrcString = function () {
     return this._invokeCMake("getCmakeJsSrcString");
 };
 
+BuildSystem.prototype.getCmakeJsSrcCString = function () {
+    return this._invokeCMake("getCmakeJsSrcCString");
+};
+
 BuildSystem.prototype.configure = function () {
     return this._invokeCMake("configure");
 };

--- a/lib/c/win_delay_load_hook.c
+++ b/lib/c/win_delay_load_hook.c
@@ -1,0 +1,52 @@
+/*
+ * When this file is linked to a DLL, it sets up a delay-load hook that
+ * intervenes when the DLL is trying to load 'node.exe' or 'iojs.exe'
+ * dynamically. Instead of trying to locate the .exe file it'll just return
+ * a handle to the process image.
+ *
+ * This allows compiled addons to work when node.exe or iojs.exe is renamed.
+ */
+
+#ifdef _MSC_VER
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#include <windows.h>
+
+#include <delayimp.h>
+#include <string.h>
+
+static HMODULE node_dll = NULL;
+static HMODULE nw_dll = NULL;
+
+static FARPROC WINAPI load_exe_hook(unsigned int event, DelayLoadInfo* info) {
+  if (event == dliNotePreGetProcAddress) {
+    FARPROC ret = NULL;
+    ret = GetProcAddress(node_dll, info->dlp.szProcName);
+    if (ret)
+      return ret;
+    ret = GetProcAddress(nw_dll, info->dlp.szProcName);
+    return ret;
+  }
+  if (event == dliStartProcessing) {
+    node_dll = GetModuleHandleA("node.dll");
+    nw_dll = GetModuleHandleA("nw.dll");
+    return NULL;
+  }
+  if (event != dliNotePreLoadLibrary)
+    return NULL;
+
+  if (_stricmp(info->szDll, "node.exe") != 0)
+    return NULL;
+  
+  // Fall back to the current process
+  if(!node_dll) node_dll = GetModuleHandleA(NULL);
+
+  return (FARPROC) node_dll;
+}
+
+const PfnDliHook __pfnDliNotifyHook2 = load_exe_hook;
+
+#endif

--- a/lib/cMake.js
+++ b/lib/cMake.js
@@ -151,6 +151,9 @@ CMake.prototype.getConfigureCommand = async function () {
     // Sources:
     const srcsString = this.getCmakeJsSrcString();
     D.push({ "CMAKE_JS_SRC": srcsString });
+    const srccString = this.getCmakeJsSrcString();
+    D.push({ "CMAKE_JS_SRC_C": srccString });
+
 
     // Runtime:
     D.push({"NODE_RUNTIME": this.targetOptions.runtime});
@@ -279,6 +282,17 @@ CMake.prototype.getCmakeJsSrcString = function () {
     const srcPaths = [];
     if (environment.isWin) {
         const delayHook = path.normalize(path.join(__dirname, 'cpp', 'win_delay_load_hook.cc'));
+
+        srcPaths.push(delayHook.replace(/\\/gm, '/'));
+    }
+
+    return srcPaths.join(";");
+};
+
+CMake.prototype.getCmakeJsSrcCString = function () {
+    const srcPaths = [];
+    if (environment.isWin) {
+        const delayHook = path.normalize(path.join(__dirname, 'c', 'win_delay_load_hook.c'));
 
         srcPaths.push(delayHook.replace(/\\/gm, '/'));
     }


### PR DESCRIPTION
Support windows delay load hook in C. 
I create a new MACRO for c source as I'm not sure if there is a better way to detect the project language in cmake-js. Feel free to update the PR. 