### PR TITLE
feat: use the XDG Base Directory Specification for the cache folder

### DIFF
--- a/lib/dist.js
+++ b/lib/dist.js
@@ -21,7 +21,15 @@ function testSum(sums, sum, fPath) {
 
 class Dist {
 	get internalPath() {
-		const cacheDirectory = '.cmake-js'
+		const cacheDirectoryName = 'cmake-js'
+		const cacheDirectory = path.join(
+			process.env.XDG_CACHE_HOME ?? path.join(
+				os.homedir(),
+				'.cache'
+			),
+			cacheDirectoryName
+		)
+		
 		const runtimeArchDirectory = this.targetOptions.runtime + '-' + this.targetOptions.arch
 		const runtimeVersionDirectory = 'v' + this.targetOptions.runtimeVersion
 


### PR DESCRIPTION
Uses `XDG_CACHE_HOME/cmake-js` instead of `~/.cmake-js`.

I yet haven't added functionality to migrate the old cache to the new cache path since I am not sure if the maintainers would like to do that.