### PR TITLE
Include parent folders to parse for `package.json` in determining `isNodeApi`

### DIFF
--- a/lib/buildSystem.js
+++ b/lib/buildSystem.js
@@ -5,17 +5,26 @@ const CMLog = require('./cmLog')
 const appCMakeJSConfig = require('./appCMakeJSConfig')
 const npmConfig = require('./npmConfig')
 const path = require('path')
+const fs = require("fs")
 const Toolset = require('./toolset')
 
+function findPackageJson(folderPath){
+    if(path.resolve(folderPath) === path.resolve('/')) return false;
+
+    const pkgJsonPath = path.join(folderPath, 'package.json')
+    if(fs.existsSync(pkgJsonPath)) return pkgJsonPath
+
+    return findPackageJson(path.join(folderPath, '../'))
+}
 function isNodeApi(log, projectRoot) {
-	try {
-		const projectPkgJson = require(path.join(projectRoot, 'package.json'))
-		// Make sure the property exists
-		return !!projectPkgJson?.binary?.napi_versions
-	} catch (e) {
-		log.silly('CFG', "'package.json' not found.")
-		return false
-	}
+    const pkgJsonPath = findPackageJson(projectRoot)
+    if(!pkgJsonPath ){
+        log.silly("CFG", "'package.json' not found.");
+        return false
+    }
+
+    const projectPkgJson = require(pkgJsonPath)
+    return !!projectPkgJson?.binary?.napi_versions
 }
 
 class BuildSystem {


### PR DESCRIPTION
The present code logic of cmake-js, in order to determine `isNodeApi`, assumes that `package.json` and `CMakeList.txt` are co-located in a folder. If `package.json` is not found in the same folder, an error is logged in `silly` mode, which for most consumers is a silent failure.

This PR redresses the issue by recursively searching parent folders until `package.json` is found and it's path returned, or the system root file folder is reached, upon which `false` is returned