### PR TITLE
Modernize CMakeLists.txt example

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ In a nutshell. _(For more complete documentation please see [the first tutorial]
 cmake_minimum_required(VERSION 3.15...3.31)
 project(your-addon-name-here)
 
-add_definitions(-DNAPI_VERSION=4)
+add_compile_definitions(-DNAPI_VERSION=4)
 
 file(GLOB SOURCE_FILES "your-source files-location-here")
 

--- a/README.md
+++ b/README.md
@@ -106,21 +106,18 @@ In a nutshell. _(For more complete documentation please see [the first tutorial]
 - Put a CMakeLists.txt file into your module root with this minimal required content:
 
 ```cmake
-cmake_minimum_required(VERSION 3.15)
-cmake_policy(SET CMP0091 NEW)
-cmake_policy(SET CMP0042 NEW)
-
-project (your-addon-name-here)
+cmake_minimum_required(VERSION 3.15...3.31)
+project(your-addon-name-here)
 
 add_definitions(-DNAPI_VERSION=4)
-
-include_directories(${CMAKE_JS_INC})
 
 file(GLOB SOURCE_FILES "your-source files-location-here")
 
 add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES} ${CMAKE_JS_SRC})
 set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "" SUFFIX ".node")
-target_link_libraries(${PROJECT_NAME} ${CMAKE_JS_LIB})
+target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_JS_INC})
+target_link_libraries(${PROJECT_NAME} PRIVATE ${CMAKE_JS_LIB})
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 
 if(MSVC AND CMAKE_JS_NODELIB_DEF AND CMAKE_JS_NODELIB_TARGET)
   # Generate node.lib


### PR DESCRIPTION
Note that using `file(GLOB)` for defining the sources list is considered a bad practice in CMake https://cmake.org/cmake/help/v3.31/command/file.html#glob, we might want to change that to listing them explicitly rather than giving a bad sample